### PR TITLE
Add OpenPencil direct-drive editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ DSH OpenPencil is an intelligent design plugin that connects DeepSeek Harness wi
 
 ## What works
 
-- `design_render` creates an immutable, content-addressed `.op` snapshot.
+- `openpencil_render` creates an immutable, content-addressed `.op` snapshot and renders every top-level frame on the active page.
+- `openpencil_selection` reads the exact nodes selected in the live sidebar canvas.
+- `openpencil_create` applies a transactional OpenPencil `batch_design` program to generate or restructure canvas nodes.
+- `openpencil_edit` modifies an explicit node or the single node selected by the user.
 - OpenPencil's installed headless exporter is the default, design-fidelity renderer.
 - The tool card shows the first top-level frame as a large replay-safe PNG. Multi-frame documents add a horizontally scrollable thumbnail rail, click-to-select, and previous/next navigation.
 - The large preview supports manual zoom, reset, fit-frame, and fit-content modes.
@@ -34,16 +37,16 @@ Use an authenticated DSH prerelease without installing it globally:
 
 ```sh
 git clone git@github.com:dsh-external/dsh-openpencil.git
-npx --yes -p @deepseek-ai/dsh@0.0.1-rc.1 \
+npx --yes -p @deepseek-ai/dsh@0.0.1-rc.2 \
   dsh plugin --profile web add /absolute/path/to/dsh-openpencil
-npx --yes -p @deepseek-ai/dsh@0.0.1-rc.1 dsh web
+npx --yes -p @deepseek-ai/dsh@0.0.1-rc.2 dsh web
 ```
 
 Keep the private registry credential in a user-level or temporary npm config outside the checkout. This repository intentionally contains no registry credentials.
 
 ## Rendering contract
 
-`design_render` accepts a `.op` path, an optional `scale` (`0 < scale <= 8`, default `1`), and optional `editable` (`false` by default). Leave `width` and `height` unset for the exact OpenPencil path: they describe a runtime viewport, not design export dimensions, and are accepted only by the lower-fidelity Jian fallback.
+`openpencil_render` accepts a `.op` path, an optional `scale` (`0 < scale <= 8`, default `1`), and optional `editable` (`false` by default). Leave `width` and `height` unset for the exact OpenPencil path: they describe a runtime viewport, not design export dimensions, and are accepted only by the lower-fidelity Jian fallback.
 
 OpenPencil binary discovery checks, in order:
 
@@ -92,7 +95,7 @@ Builds require Node 24.11 or newer. DSH host/client packages are peer dependenci
 For a private DSH prerelease, keep the issued npm credential outside this repository (for example in a user-level or temporary `.npmrc`) and run the requested version directly:
 
 ```sh
-npx --yes -p @deepseek-ai/dsh@0.0.1-rc.1 dsh web
+npx --yes -p @deepseek-ai/dsh@0.0.1-rc.2 dsh web
 ```
 
 Never commit `.npmrc`, `NPM_TOKEN`, or copied registry credentials. This repository ignores local npm configuration by default.
@@ -113,7 +116,7 @@ The result also records `renderer`, `rendererBinary`, `fidelity`, and any warnin
 
 ## Current limits
 
-- `design_create` and `design_edit` are not implemented by this package.
+- Canvas generation and node edits require an already-open managed sidebar editor. Changes remain unsaved until the user or Agent explicitly invokes the sidebar Save action.
 - The lightweight Web SDK canvas is read-only; full editing uses the separate managed sidebar editor.
 - The exact gallery covers top-level frames on the active page; the interactive canvas remains the way to inspect inactive pages and nested nodes.
 - Render and snapshot caches still need a product-level retention policy.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ DeepSeek Harness plugin for previewing and editing OpenPencil `.op` documents in
 
 **中文**
 
-DSH OpenPencil 是连接 DeepSeek Harness 与 OpenPencil 的智能设计插件，目标是让 Agent 直接驱动真实、可编辑、可交互的设计画布，而不是只返回一张生成图片。它支持在对话中渲染和浏览多页面 `.op` 设计稿，一键进入可缩放画布或完整侧边栏编辑器，继续使用 OpenPencil 的图层、属性、绘制、组件、交互和多类模板能力，快速创建 App 页面、演示文稿、社交媒体内容、信息图等不同类型的设计；同时让 DeepSeek Harness 中的 Agent 理解画布结构、节点、选区、组件关系与交互逻辑，直接调用模板、生成页面、修改组件、调整布局、编排交互、检查视觉质量并保存结果，把“对话提出需求—Agent 操作真实画布—实时预览与交互验证—继续迭代”整合成一条完整设计工作流。
+DSH OpenPencil 是连接 DeepSeek Harness 与 OpenPencil 的智能设计插件，目标是让 Agent 直接驱动真实、可编辑、可交互的设计画布，而不是只返回一张生成图片。它支持在对话中渲染和浏览多页面 `.op` 设计稿，一键进入可缩放画布或完整编辑器（在支持的 DSH 中使用原生右侧详情栏，rc.2 则自动回退到插件全屏编辑面板），继续使用 OpenPencil 的图层、属性、绘制、组件、交互和多类模板能力，快速创建 App 页面、演示文稿、社交媒体内容、信息图等不同类型的设计；同时让 DeepSeek Harness 中的 Agent 理解画布结构、节点、选区、组件关系与交互逻辑，直接调用模板、生成页面、修改组件、调整布局、编排交互、检查视觉质量并保存结果，把“对话提出需求—Agent 操作真实画布—实时预览与交互验证—继续迭代”整合成一条完整设计工作流。
 
 **English**
 
-DSH OpenPencil is an intelligent design plugin that connects DeepSeek Harness with OpenPencil. Its goal is to let an Agent directly operate a real, editable, and interactive design canvas instead of returning only a generated image. It can render and browse multi-page `.op` designs inside a conversation, then open them in a zoomable canvas or the full sidebar editor. From there, users retain OpenPencil's layers, properties, drawing tools, components, interactions, and broad template library for creating app screens, presentations, social media content, infographics, and more. At the same time, the Agent can understand the canvas structure, nodes, selections, component relationships, and interaction logic; invoke templates; generate pages; modify components; adjust layouts; orchestrate interactions; inspect visual quality; and save the result. This brings requirement gathering, direct Agent-driven canvas editing, live preview and interaction validation, and continued iteration into one complete design workflow.
+DSH OpenPencil is an intelligent design plugin that connects DeepSeek Harness with OpenPencil. Its goal is to let an Agent directly operate a real, editable, and interactive design canvas instead of returning only a generated image. It can render and browse multi-page `.op` designs inside a conversation, then open them in a zoomable canvas or the full editor. Hosts with the native Tool-details seam use DSH's right-hand details panel; stock rc.2 automatically falls back to the plugin's full-screen editor. From there, users retain OpenPencil's layers, properties, drawing tools, components, interactions, and broad template library for creating app screens, presentations, social media content, infographics, and more. At the same time, the Agent can understand the canvas structure, nodes, selections, component relationships, and interaction logic; invoke templates; generate pages; modify components; adjust layouts; orchestrate interactions; inspect visual quality; and save the result. This brings requirement gathering, direct Agent-driven canvas editing, live preview and interaction validation, and continued iteration into one complete design workflow.
 
 ## What works
 
@@ -24,7 +24,7 @@ DSH OpenPencil is an intelligent design plugin that connects DeepSeek Harness wi
 - The tool card shows the first top-level frame as a large replay-safe PNG. Multi-frame documents add a horizontally scrollable thumbnail rail, click-to-select, and previous/next navigation.
 - The large preview supports manual zoom, reset, fit-frame, and fit-content modes.
 - “Open interactive canvas” lazily mounts the read-only OpenPencil Web SDK. The canvas supports pan, zoom, and fit.
-- With `editable: true`, “Edit in sidebar” opens the managed OpenPencil editor with selection, layers, properties, drawing tools, undo/redo, and explicit save semantics.
+- With `editable: true`, the edit action opens the managed OpenPencil editor with selection, layers, properties, drawing tools, undo/redo, and explicit save semantics. It prefers DSH's native Tool-details sidebar and falls back to a full-screen plugin modal on stock rc.2.
 - The tool card and managed editor follow DSH's Chinese/English locale and light/dark theme without reloading the editing session.
 - Image and document grants are signed, hash-bound capabilities. Browser metadata does not expose an arbitrary host path.
 - If the exact OpenPencil binary is genuinely unavailable, Jian may produce a clearly labelled `runtime-preview` fallback. Exact renderer failures, timeouts, and invalid PNGs do not silently fall back.
@@ -71,7 +71,7 @@ Viewer assets are lazy-loaded only after the user opens the canvas. If they are 
 
 ## Managed editor
 
-Editable sessions use OpenPencil's managed web host, the same architecture used by `op-vscode`. The plugin starts the host only after an authorized user action, keeps the daemon token in memory, validates iframe source and origin, and closes the process when the editor session ends.
+Editable sessions use OpenPencil's managed web host, the same architecture used by `op-vscode`. The plugin starts the host only after an authorized user action, keeps the daemon token in memory, validates iframe source and origin, and closes the process when the editor session ends. The editor surface is selected progressively: native Tool details when the host declares that seam, otherwise the plugin's full-screen modal.
 
 Binary and source discovery can be overridden with:
 
@@ -116,7 +116,7 @@ The result also records `renderer`, `rendererBinary`, `fidelity`, and any warnin
 
 ## Current limits
 
-- Canvas generation and node edits require an already-open managed sidebar editor. Changes remain unsaved until the user or Agent explicitly invokes the sidebar Save action.
-- The lightweight Web SDK canvas is read-only; full editing uses the separate managed sidebar editor.
+- Canvas generation and node edits require an already-open managed editor. Changes remain unsaved until the user or Agent explicitly invokes its Save action.
+- The lightweight Web SDK canvas is read-only; full editing uses the separate managed editor surface (native details sidebar when available, full-screen fallback on stock rc.2).
 - The exact gallery covers top-level frames on the active page; the interactive canvas remains the way to inspect inactive pages and nested nodes.
 - Render and snapshot caches still need a product-level retention policy.

--- a/lib/client.js
+++ b/lib/client.js
@@ -924,6 +924,160 @@ function ManagedOpenPencilEditor({ grant, colorScheme, locale, sessionId }) {
 	});
 }
 //#endregion
+//#region src/client/details-compat.ts
+/** Prefer the native resident details panel and otherwise open our own modal. */
+function requestOpenPencilEditor(openDetails, openModal) {
+	if (openDetails !== void 0) {
+		openDetails();
+		return "details";
+	}
+	openModal();
+	return "modal";
+}
+//#endregion
+//#region src/client/editor-modal.tsx
+/** Managed OpenPencil editor fallback for DSH builds without Tool details. */
+const EDITOR_MODAL_COPY = {
+	"zh-CN": {
+		title: "OpenPencil 编辑器",
+		close: "关闭",
+		discard: "OpenPencil 中有未保存的更改，确定关闭并放弃吗？"
+	},
+	"en-US": {
+		title: "OpenPencil editor",
+		close: "Close",
+		discard: "OpenPencil has unsaved changes. Close and discard them?"
+	}
+};
+function editorModalCopy(locale) {
+	return EDITOR_MODAL_COPY[locale];
+}
+/** Read the editor's durable dirty marker before allowing the modal to close. */
+function confirmEditorModalClose(root, message, confirm = window.confirm) {
+	return confirmEditorClose((root?.querySelector("[data-tool-details-dirty=\"true\"]") ?? null) !== null, () => confirm(message));
+}
+const modalStyles = {
+	backdrop: {
+		position: "fixed",
+		inset: 0,
+		zIndex: 2147483e3,
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		padding: 20,
+		background: "rgba(0,0,0,0.72)"
+	},
+	dialog: {
+		width: "min(1440px, 96vw)",
+		height: "min(960px, 94vh)",
+		minWidth: 0,
+		minHeight: 0,
+		display: "flex",
+		flexDirection: "column",
+		overflow: "hidden",
+		border: "1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.5))",
+		borderRadius: 10,
+		color: "var(--dsw-alias-label-primary, #eee)",
+		background: "var(--dsw-alias-bg-base, #17171a)",
+		boxShadow: "0 24px 80px rgba(0,0,0,0.45)"
+	},
+	header: {
+		minHeight: 44,
+		display: "flex",
+		alignItems: "center",
+		gap: 8,
+		padding: "7px 10px",
+		borderBottom: "1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.3))"
+	},
+	title: {
+		minWidth: 0,
+		marginRight: "auto",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
+		fontSize: 13
+	},
+	close: {
+		minHeight: 28,
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		border: "1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.45))",
+		borderRadius: 6,
+		color: "var(--dsw-alias-label-primary, inherit)",
+		background: "var(--dsw-alias-bg-layer-1, transparent)",
+		padding: "4px 9px",
+		cursor: "pointer",
+		font: "inherit",
+		fontSize: 12,
+		lineHeight: 1
+	},
+	body: {
+		flex: 1,
+		minHeight: 0,
+		overflow: "hidden"
+	}
+};
+function ManagedOpenPencilEditorModal({ grant, colorScheme, locale, sessionId, onClose }) {
+	const bodyRef = (0, react.useRef)(null);
+	const closeRef = (0, react.useRef)(null);
+	const titleId = (0, react.useId)();
+	const copy = editorModalCopy(locale);
+	const requestClose = (0, react.useCallback)(() => {
+		if (!confirmEditorModalClose(bodyRef.current, copy.discard)) return;
+		onClose();
+	}, [copy.discard, onClose]);
+	(0, react.useEffect)(() => {
+		closeRef.current?.focus();
+		const onKeyDown = (event) => {
+			if (event.key !== "Escape") return;
+			event.preventDefault();
+			requestClose();
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => {
+			window.removeEventListener("keydown", onKeyDown);
+		};
+	}, [requestClose]);
+	return /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
+		style: modalStyles.backdrop,
+		role: "presentation",
+		"data-openpencil-editor-modal": "true",
+		onMouseDown: (event) => {
+			if (event.target === event.currentTarget) requestClose();
+		},
+		children: /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("section", {
+			style: modalStyles.dialog,
+			role: "dialog",
+			"aria-modal": "true",
+			"aria-labelledby": titleId,
+			children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
+				style: modalStyles.header,
+				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("strong", {
+					id: titleId,
+					style: modalStyles.title,
+					children: copy.title
+				}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
+					ref: closeRef,
+					type: "button",
+					style: modalStyles.close,
+					onClick: requestClose,
+					children: copy.close
+				})]
+			}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
+				ref: bodyRef,
+				style: modalStyles.body,
+				children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(ManagedOpenPencilEditor, {
+					grant,
+					colorScheme,
+					locale,
+					sessionId
+				})
+			})]
+		})
+	});
+}
+//#endregion
 //#region src/client/frame-gallery.tsx
 const FRAME_GALLERY_COPY = {
 	en: {
@@ -1717,6 +1871,7 @@ const DESIGN_RENDER_COPY = {
 		renderFailed: "The render failed.",
 		frames: "frames",
 		openInteractiveCanvas: "Open interactive canvas",
+		editCanvas: "Edit canvas",
 		editInSidebar: "Edit in sidebar",
 		openRenderedPng: "Open rendered PNG",
 		downloadPng: "Download PNG",
@@ -1747,6 +1902,7 @@ const DESIGN_RENDER_COPY = {
 		renderFailed: "渲染失败。",
 		frames: "页",
 		openInteractiveCanvas: "打开交互画布",
+		editCanvas: "编辑画布",
 		editInSidebar: "在侧边栏编辑",
 		openRenderedPng: "打开渲染 PNG",
 		downloadPng: "下载 PNG",
@@ -2334,7 +2490,7 @@ function CanvasModal({ grant, onClose, locale }) {
 	});
 }
 /** Render one OpenPencil render tool call as a PNG-first card. */
-function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en" }) {
+function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en", colorScheme = "light", editorLocale, sessionId }) {
 	const settled = "kind" in block;
 	const error = settled && block.isError;
 	const running = !settled;
@@ -2346,7 +2502,9 @@ function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en"
 	const currentFrameIndex = normalizeFrameIndex(selectedFrameIndex, frames.length);
 	const selectedFrame = frames[currentFrameIndex] ?? grant?.image;
 	const [modalToken, setModalToken] = (0, react.useState)();
+	const [editorModalOpen, setEditorModalOpen] = (0, react.useState)(false);
 	const releaseRef = (0, react.useRef)();
+	const resolvedEditorLocale = editorLocale ?? editorLocaleFromDsh(locale);
 	const closeCanvas = (0, react.useCallback)(() => {
 		releaseRef.current?.();
 		releaseRef.current = void 0;
@@ -2360,6 +2518,11 @@ function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en"
 		});
 		setModalToken(token);
 	}, []);
+	const openEditor = (0, react.useCallback)(() => {
+		requestOpenPencilEditor(openDetails, () => {
+			setEditorModalOpen(true);
+		});
+	}, [openDetails]);
 	(0, react.useEffect)(() => () => {
 		releaseRef.current?.();
 	}, []);
@@ -2438,8 +2601,8 @@ function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en"
 							grant.document !== void 0 && grant.editor?.enabled === true ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								style: styles.primaryButton,
-								onClick: openDetails,
-								children: copy.editInSidebar
+								onClick: openEditor,
+								children: openDetails === void 0 ? copy.editCanvas : copy.editInSidebar
 							}) : null,
 							selectedFrame !== void 0 && openFile !== void 0 ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
@@ -2493,6 +2656,15 @@ function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en"
 				grant,
 				onClose: closeCanvas,
 				locale
+			}) : null,
+			editorModalOpen && grant?.document !== void 0 && grant.editor?.enabled === true ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)(ManagedOpenPencilEditorModal, {
+				grant,
+				colorScheme,
+				locale: resolvedEditorLocale,
+				sessionId: String(sessionId),
+				onClose: () => {
+					setEditorModalOpen(false);
+				}
 			}) : null
 		]
 	});
@@ -2526,9 +2698,12 @@ function apply(ctx) {
 	const getEditorLocale = () => editorLocaleFromDsh(getLocale());
 	const HostSyncedDesignRenderView = (props) => {
 		const locale = (0, react.useSyncExternalStore)(subscribeLocale, getLocale, getLocale);
+		const colorScheme = (0, react.useSyncExternalStore)(subscribeTheme, getColorScheme, getColorScheme);
 		return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(DesignRenderView, {
 			...props,
-			locale
+			locale,
+			editorLocale: editorLocaleFromDsh(locale),
+			colorScheme
 		});
 	};
 	const HostSyncedOpenPencilEditorPanel = (props) => {
@@ -2585,6 +2760,7 @@ exports.clampGalleryZoom = clampGalleryZoom;
 exports.clearOpenPencilSelection = clearOpenPencilSelection;
 exports.closeManagedEditorLaunch = closeManagedEditorLaunch;
 exports.confirmEditorClose = confirmEditorClose;
+exports.confirmEditorModalClose = confirmEditorModalClose;
 exports.designRenderCopy = designRenderCopy;
 exports.editorControlUrl = editorControlUrl;
 exports.editorGrantForBoot = editorGrantForBoot;
@@ -2592,6 +2768,7 @@ exports.editorIframeUrlWithLocale = editorIframeUrlWithLocale;
 exports.editorIframeUrlWithTheme = editorIframeUrlWithTheme;
 exports.editorLocaleFromDsh = editorLocaleFromDsh;
 exports.editorMessageFrom = editorMessageFrom;
+exports.editorModalCopy = editorModalCopy;
 exports.editorOrigin = editorOrigin;
 exports.editorPanelCopy = editorPanelCopy;
 exports.editorSuccessorFromSave = editorSuccessorFromSave;
@@ -2618,6 +2795,7 @@ exports.prepareManagedEditor = prepareManagedEditor;
 exports.prepareManagedEditorForMount = prepareManagedEditorForMount;
 exports.publishOpenPencilSelection = publishOpenPencilSelection;
 exports.rememberEditorSuccessor = rememberEditorSuccessor;
+exports.requestOpenPencilEditor = requestOpenPencilEditor;
 exports.selectionNodeDetail = selectionNodeDetail;
 exports.selectionNodeLabel = selectionNodeLabel;
 exports.sizeCanvasForDisplay = sizeCanvasForDisplay;

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 let react = require("react");
 let react_jsx_runtime = require("react/jsx-runtime");
 //#region src/client/editor-bridge.ts
-function isRecord$3(value) {
+function isRecord$4(value) {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function safeInteger(value) {
@@ -22,7 +22,7 @@ function parseEditorInbound(raw) {
 	} catch {
 		return;
 	}
-	if (!isRecord$3(value) || typeof value.type !== "string") return void 0;
+	if (!isRecord$4(value) || typeof value.type !== "string") return void 0;
 	switch (value.type) {
 		case "op-bridge/ready": return safeInteger(value.generation) && safeInteger(value.revision) ? {
 			type: value.type,
@@ -127,7 +127,7 @@ function confirmEditorClose(dirty, confirm = window.confirm) {
 //#region src/client/editor-successor.ts
 /** Session-scoped successor capabilities for reopening a saved editor card. */
 const STORAGE_PREFIX = "dsh-openpencil:editor-successor:v1:";
-function isRecord$2(value) {
+function isRecord$3(value) {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function browserStorage() {
@@ -148,7 +148,7 @@ function editorSuccessorStorageKey(originalLaunchUrl, baseUrl = window.location.
 	return `${STORAGE_PREFIX}${editorControlUrl(originalLaunchUrl, baseUrl)}`;
 }
 function persistedSuccessorOf(value, baseUrl) {
-	if (!isRecord$2(value)) return void 0;
+	if (!isRecord$3(value)) return void 0;
 	const launchUrl = value.launchUrl;
 	const refreshUrl = value.refreshUrl;
 	if (typeof launchUrl !== "string" || launchUrl.length === 0 || typeof refreshUrl !== "string" || refreshUrl.length === 0) return void 0;
@@ -163,7 +163,7 @@ function persistedSuccessorOf(value, baseUrl) {
 }
 /** Parse only the successor grant from a successful save response. */
 function editorSuccessorFromSave(value, baseUrl = window.location.href) {
-	if (!isRecord$2(value) || !isRecord$2(value.editor) || value.editor.enabled !== true) return void 0;
+	if (!isRecord$3(value) || !isRecord$3(value.editor) || value.editor.enabled !== true) return void 0;
 	const persisted = persistedSuccessorOf(value.editor, baseUrl);
 	return persisted === void 0 ? void 0 : {
 		enabled: true,
@@ -219,6 +219,147 @@ function editorGrantForBoot(original, options = {}) {
 	return original;
 }
 //#endregion
+//#region src/client/selection-store.ts
+const stores = /* @__PURE__ */ new Map();
+const listeners = /* @__PURE__ */ new Map();
+const EMPTY_SELECTION_STORE_SNAPSHOT = Object.freeze({ revision: 0 });
+function isRecord$2(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function finite(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : void 0;
+}
+function nodeOf(value) {
+	if (!isRecord$2(value) || typeof value.id !== "string" || value.id.length === 0) return void 0;
+	return {
+		id: value.id,
+		...typeof value.type === "string" && value.type.length > 0 ? { type: value.type } : {},
+		...typeof value.name === "string" && value.name.length > 0 ? { name: value.name } : {},
+		...finite(value.x) === void 0 ? {} : { x: finite(value.x) },
+		...finite(value.y) === void 0 ? {} : { y: finite(value.y) },
+		...finite(value.width) === void 0 ? {} : { width: finite(value.width) },
+		...finite(value.height) === void 0 ? {} : { height: finite(value.height) }
+	};
+}
+function liveSelectionOf(value) {
+	if (!isRecord$2(value) || typeof value.sourcePath !== "string" || value.sourcePath.length === 0) return void 0;
+	return {
+		sourcePath: value.sourcePath,
+		activePageId: typeof value.activePageId === "string" ? value.activePageId : "",
+		selectedIds: Array.isArray(value.selectedIds) ? value.selectedIds.filter((id) => typeof id === "string" && id.length > 0) : [],
+		nodes: Array.isArray(value.nodes) ? value.nodes.map(nodeOf).filter((node) => node !== void 0) : [],
+		updatedAt: finite(value.updatedAt) ?? Date.now()
+	};
+}
+function sameSelection(a, b) {
+	if (a === void 0 || b === void 0) return a === b;
+	return a.sourcePath === b.sourcePath && a.activePageId === b.activePageId && JSON.stringify(a.selectedIds) === JSON.stringify(b.selectedIds) && JSON.stringify(a.nodes) === JSON.stringify(b.nodes);
+}
+function publishOpenPencilSelection(sessionId, selection) {
+	const current = stores.get(sessionId) ?? { revision: 0 };
+	if (sameSelection(current.selection, selection)) return;
+	stores.set(sessionId, {
+		revision: current.revision + 1,
+		selection
+	});
+	for (const listener of listeners.get(sessionId) ?? []) listener();
+}
+function clearOpenPencilSelection(sessionId, sourcePath) {
+	const current = stores.get(sessionId);
+	if (current === void 0) return;
+	if (current.selection === void 0) return;
+	if (sourcePath !== void 0 && current.selection.sourcePath !== sourcePath) return;
+	stores.set(sessionId, { revision: current.revision + 1 });
+	for (const listener of listeners.get(sessionId) ?? []) listener();
+}
+function subscribeOpenPencilSelection(sessionId, listener) {
+	let scoped = listeners.get(sessionId);
+	if (scoped === void 0) {
+		scoped = /* @__PURE__ */ new Set();
+		listeners.set(sessionId, scoped);
+	}
+	scoped.add(listener);
+	return () => {
+		scoped?.delete(listener);
+		if (scoped?.size === 0) listeners.delete(sessionId);
+	};
+}
+function getOpenPencilSelectionSnapshot(sessionId) {
+	return stores.get(sessionId) ?? EMPTY_SELECTION_STORE_SNAPSHOT;
+}
+//#endregion
+//#region src/client/selection-polling.ts
+const DEFAULT_INTERVAL_MS = 400;
+const DEFAULT_TIMER = {
+	schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+	cancel: (handle) => {
+		clearTimeout(handle);
+	}
+};
+/** Client failures other than retry-oriented HTTP statuses cannot recover by polling. */
+function isTerminalEditorSelectionStatus(status) {
+	return status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429;
+}
+/**
+* Start one immediate poll followed by non-overlapping delayed polls.
+*
+* The returned cleanup is idempotent, aborts an in-flight request, cancels the
+* pending timer, and invokes `onStop` exactly once. Terminal HTTP responses
+* use the same cleanup path; network errors and retryable statuses schedule a
+* later attempt without disrupting the editor itself.
+*/
+function startEditorSelectionPolling(options) {
+	const fetcher = options.fetcher ?? fetch;
+	const timer = options.timer ?? DEFAULT_TIMER;
+	const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+	let stopped = false;
+	let timerHandle;
+	let requestAbort;
+	const stop = () => {
+		if (stopped) return;
+		stopped = true;
+		if (timerHandle !== void 0) {
+			timer.cancel(timerHandle);
+			timerHandle = void 0;
+		}
+		requestAbort?.abort();
+		requestAbort = void 0;
+		options.onStop();
+	};
+	const schedule = () => {
+		if (stopped) return;
+		timerHandle = timer.schedule(() => {
+			timerHandle = void 0;
+			poll();
+		}, intervalMs);
+	};
+	const poll = async () => {
+		if (stopped) return;
+		const abort = new AbortController();
+		requestAbort = abort;
+		try {
+			const response = await fetcher(options.url, {
+				credentials: "same-origin",
+				signal: abort.signal
+			});
+			if (stopped) return;
+			if (isTerminalEditorSelectionStatus(response.status)) {
+				stop();
+				return;
+			}
+			if (response.ok) {
+				const value = await response.json();
+				if (!stopped) options.onValue(value);
+			}
+		} catch {} finally {
+			if (requestAbort === abort) requestAbort = void 0;
+			schedule();
+		}
+	};
+	poll();
+	return stop;
+}
+//#endregion
 //#region src/client/editor-panel.tsx
 /** Full OpenPencil editor hosted in DSH's Tool details side panel. */
 const DEFAULT_REFRESH_URL = "/_dsh/dsh-openpencil/editor/refresh";
@@ -239,6 +380,7 @@ function launchResponseOf(value) {
 		iframeUrl: value.iframeUrl,
 		token: value.token,
 		saveUrl: editorControlUrl(value.saveUrl),
+		...typeof value.selectionUrl === "string" && value.selectionUrl.length > 0 ? { selectionUrl: editorControlUrl(value.selectionUrl) } : {},
 		closeUrl: editorControlUrl(value.closeUrl),
 		...typeof value.docJson === "string" ? { docJson: value.docJson } : {}
 	};
@@ -285,10 +427,14 @@ const EDITOR_PANEL_COPY = {
 function editorPanelCopy(locale) {
 	return EDITOR_PANEL_COPY[locale];
 }
-function launchRequest(fetcher, url, signal) {
+function launchRequest(fetcher, url, signal, sessionId) {
 	return fetcher(editorControlUrl(url), {
 		method: "POST",
 		credentials: "same-origin",
+		...sessionId === void 0 ? {} : {
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ sessionId })
+		},
 		...signal === void 0 ? {} : { signal }
 	});
 }
@@ -301,7 +447,7 @@ async function launchManagedEditor(editor, document, options = {}) {
 	const fetcher = options.fetcher ?? fetch;
 	let launchUrl = editor.launchUrl;
 	let renewed = false;
-	let response = await launchRequest(fetcher, launchUrl, options.signal);
+	let response = await launchRequest(fetcher, launchUrl, options.signal, options.sessionId);
 	if (response.status === 410) {
 		if (document.path === void 0) throw new Error("OpenPencil editor launch expired and cannot be refreshed without a source path");
 		launchUrl = refreshedLaunchUrlOf(await responseJson(await fetcher(editorControlUrl(editor.refreshUrl ?? DEFAULT_REFRESH_URL), {
@@ -316,7 +462,7 @@ async function launchManagedEditor(editor, document, options = {}) {
 			...options.signal === void 0 ? {} : { signal: options.signal }
 		}), "OpenPencil editor refresh"));
 		renewed = true;
-		response = await launchRequest(fetcher, launchUrl, options.signal);
+		response = await launchRequest(fetcher, launchUrl, options.signal, options.sessionId);
 	}
 	const launch = launchResponseOf(await responseJson(response, "OpenPencil editor launch"));
 	return renewed ? {
@@ -331,20 +477,53 @@ async function prepareManagedEditor(editor, document, options = {}) {
 		...options,
 		fetcher
 	});
-	if (launch.docJson !== void 0) return {
-		launch,
-		documentJson: launch.docJson
-	};
-	if (editor.refreshUrl !== void 0 || launch.renewed === true) throw new Error("OpenPencil editor launch omitted current docJson");
-	const documentResponse = await fetcher(editorControlUrl(document.url), {
+	try {
+		if (launch.docJson !== void 0) return {
+			launch,
+			documentJson: launch.docJson
+		};
+		if (editor.refreshUrl !== void 0 || launch.renewed === true) throw new Error("OpenPencil editor launch omitted current docJson");
+		const documentResponse = await fetcher(editorControlUrl(document.url), {
+			credentials: "same-origin",
+			...options.signal === void 0 ? {} : { signal: options.signal }
+		});
+		if (!documentResponse.ok) throw new Error(`OpenPencil document request failed (${documentResponse.status})`);
+		return {
+			launch,
+			documentJson: await documentResponse.text()
+		};
+	} catch (error) {
+		await closeManagedEditorLaunch(launch, {
+			fetcher,
+			keepalive: true
+		});
+		throw error;
+	}
+}
+/** Close exactly the managed session returned by one launch response. */
+async function closeManagedEditorLaunch(launch, options = {}) {
+	await (options.fetcher ?? fetch)(launch.closeUrl, {
+		method: "DELETE",
 		credentials: "same-origin",
-		...options.signal === void 0 ? {} : { signal: options.signal }
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			sessionId: launch.sessionId,
+			dirty: options.dirty ?? false
+		}),
+		...options.keepalive === void 0 ? {} : { keepalive: options.keepalive }
+	}).catch(() => {});
+}
+/**
+* Mount-aware boot boundary. React may cancel an effect after its launch POST
+* has committed; release that precise returned session before ignoring it.
+*/
+async function prepareManagedEditorForMount(editor, document, accept, options = {}) {
+	const prepared = await prepareManagedEditor(editor, document, options);
+	if (accept()) return prepared;
+	await closeManagedEditorLaunch(prepared.launch, {
+		...options.fetcher === void 0 ? {} : { fetcher: options.fetcher },
+		keepalive: true
 	});
-	if (!documentResponse.ok) throw new Error(`OpenPencil document request failed (${documentResponse.status})`);
-	return {
-		launch,
-		documentJson: await documentResponse.text()
-	};
 }
 const panelStyles = {
 	root: {
@@ -421,7 +600,7 @@ const panelStyles = {
 	}
 };
 /** Editable panel. The daemon is created lazily only while this component is mounted. */
-function ManagedOpenPencilEditor({ grant, colorScheme, locale }) {
+function ManagedOpenPencilEditor({ grant, colorScheme, locale, sessionId }) {
 	const iframeRef = (0, react.useRef)(null);
 	const launchRef = (0, react.useRef)();
 	const iframeSrcRef = (0, react.useRef)("");
@@ -432,6 +611,7 @@ function ManagedOpenPencilEditor({ grant, colorScheme, locale }) {
 	const localeRef = (0, react.useRef)(locale);
 	localeRef.current = locale;
 	const initTimerRef = (0, react.useRef)();
+	const selectionPollStopRef = (0, react.useRef)();
 	const requestCounterRef = (0, react.useRef)(0);
 	const saveWaitersRef = (0, react.useRef)(/* @__PURE__ */ new Map());
 	const [phase, setPhase] = (0, react.useState)("launching");
@@ -499,19 +679,16 @@ function ManagedOpenPencilEditor({ grant, colorScheme, locale }) {
 		const abort = new AbortController();
 		const coordinatorToken = Symbol("openpencil-editor");
 		const closeDaemon = async (dirtyAtClose = dirtyRef.current) => {
+			selectionPollStopRef.current?.();
+			selectionPollStopRef.current = void 0;
+			clearOpenPencilSelection(sessionId, documentGrant.path);
 			const launch = launchRef.current;
 			if (launch === void 0) return;
 			launchRef.current = void 0;
-			await fetch(launch.closeUrl, {
-				method: "DELETE",
-				credentials: "same-origin",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({
-					sessionId: launch.sessionId,
-					dirty: dirtyAtClose
-				}),
+			await closeManagedEditorLaunch(launch, {
+				dirty: dirtyAtClose,
 				keepalive: true
-			}).catch(() => {});
+			});
 		};
 		const releaseEditor = claimEditor(coordinatorToken, () => {
 			abort.abort();
@@ -519,9 +696,10 @@ function ManagedOpenPencilEditor({ grant, colorScheme, locale }) {
 		});
 		const boot = async () => {
 			try {
-				const { launch, documentJson } = await prepareManagedEditor(editorGrantForBoot(editorGrant), documentGrant, { signal: abort.signal });
+				const prepared = await prepareManagedEditorForMount(editorGrantForBoot(editorGrant), documentGrant, () => !cancelled && !abort.signal.aborted, { sessionId });
+				if (prepared === void 0) return;
+				const { launch, documentJson } = prepared;
 				const origin = editorOrigin(launch.iframeUrl);
-				if (cancelled) return;
 				launchRef.current = launch;
 				iframeSrcRef.current = editorIframeUrlWithLocale(editorIframeUrlWithTheme(launch.iframeUrl, colorSchemeRef.current), localeRef.current);
 				docJsonRef.current = documentJson;
@@ -549,6 +727,31 @@ function ManagedOpenPencilEditor({ grant, colorScheme, locale }) {
 		documentGrant.url,
 		editorGrant.launchUrl,
 		editorGrant.refreshUrl
+	]);
+	(0, react.useEffect)(() => {
+		if (phase !== "ready" && phase !== "saving") return;
+		const selectionUrl = launchRef.current?.selectionUrl;
+		if (selectionUrl === void 0) return;
+		const stop = startEditorSelectionPolling({
+			url: selectionUrl,
+			onValue: (value) => {
+				if (!isRecord$1(value)) return;
+				const selection = liveSelectionOf(value.selection);
+				if (selection !== void 0) publishOpenPencilSelection(sessionId, selection);
+			},
+			onStop: () => {
+				clearOpenPencilSelection(sessionId, documentGrant.path);
+			}
+		});
+		selectionPollStopRef.current = stop;
+		return () => {
+			if (selectionPollStopRef.current === stop) selectionPollStopRef.current = void 0;
+			stop();
+		};
+	}, [
+		documentGrant.path,
+		phase,
+		sessionId
 	]);
 	(0, react.useEffect)(() => {
 		const listener = (event) => {
@@ -842,10 +1045,17 @@ const GALLERY_TOOLBAR_CONTROL_LAYOUT = Object.freeze({
 	lineHeight: 1,
 	verticalAlign: "middle"
 });
+/** Optical correction for CJK labels and +/- glyphs inside the centered control box. */
+const GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT = Object.freeze({
+	display: "inline-block",
+	lineHeight: 1,
+	transform: "translateY(-1px)",
+	pointerEvents: "none"
+});
 function galleryViewportMaxHeight(fitContent) {
 	return fitContent ? void 0 : 560;
 }
-const styles$1 = {
+const styles$2 = {
 	gallery: {
 		display: "flex",
 		flexDirection: "column",
@@ -892,11 +1102,14 @@ const styles$1 = {
 		color: "var(--ui-text, inherit)",
 		background: "var(--ui-card-bg, rgba(128,128,128,0.08))",
 		cursor: "pointer",
-		font: "inherit",
+		fontFamily: "inherit",
+		fontWeight: "inherit",
+		fontStyle: "inherit",
 		fontSize: 12,
 		lineHeight: 1,
 		whiteSpace: "nowrap"
 	},
+	controlContent: GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT,
 	zoomPercent: {
 		...GALLERY_TOOLBAR_CONTROL_LAYOUT,
 		minWidth: 42,
@@ -945,7 +1158,9 @@ const styles$1 = {
 		color: "var(--ui-text, inherit)",
 		background: "var(--ui-card-bg, rgba(128,128,128,0.08))",
 		cursor: "pointer",
-		font: "inherit",
+		fontFamily: "inherit",
+		fontWeight: "inherit",
+		fontStyle: "inherit",
 		fontSize: 20,
 		lineHeight: 1
 	},
@@ -1100,25 +1315,25 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 		}
 	};
 	return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
-		style: styles$1.gallery,
+		style: styles$2.gallery,
 		role: "region",
 		"aria-roledescription": copy.carousel,
 		"aria-label": `${copy.gallery}: ${frames.length}`,
 		"data-openpencil-frame-gallery": "true",
 		children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
-			style: styles$1.mainShell,
+			style: styles$2.mainShell,
 			tabIndex: 0,
 			onKeyDown,
 			children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
-				style: styles$1.controls,
+				style: styles$2.controls,
 				children: [
 					/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", {
-						style: styles$1.currentName,
+						style: styles$2.currentName,
 						title: name,
 						children: [frames.length > 1 ? `${currentIndex + 1} / ${frames.length} · ` : "", name]
 					}),
 					/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
-						style: styles$1.zoomToolbar,
+						style: styles$2.zoomToolbar,
 						role: "toolbar",
 						"aria-label": copy.toolbar,
 						"data-openpencil-zoom-toolbar": "true",
@@ -1126,7 +1341,7 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								style: {
-									...styles$1.zoomButton,
+									...styles$2.zoomButton,
 									opacity: canZoomOut ? 1 : .42
 								},
 								disabled: !canZoomOut,
@@ -1135,18 +1350,24 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 								onClick: () => {
 									setZoom(nextGalleryZoom(zoom, -1));
 								},
-								children: "−"
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									style: styles$2.controlContent,
+									children: "−"
+								})
 							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("output", {
-								style: styles$1.zoomPercent,
+								style: styles$2.zoomPercent,
 								"aria-label": `${copy.previewZoom} ${zoomLabel}`,
 								"aria-live": "polite",
-								children: zoomLabel
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									style: styles$2.controlContent,
+									children: zoomLabel
+								})
 							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								style: {
-									...styles$1.zoomButton,
+									...styles$2.zoomButton,
 									opacity: canZoomIn ? 1 : .42
 								},
 								disabled: !canZoomIn,
@@ -1155,25 +1376,31 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 								onClick: () => {
 									setZoom(nextGalleryZoom(zoom, 1));
 								},
-								children: "+"
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									style: styles$2.controlContent,
+									children: "+"
+								})
 							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								style: {
-									...styles$1.zoomButton,
+									...styles$2.zoomButton,
 									opacity: zoomMode === "manual" && manualZoom === 1 ? .42 : 1
 								},
 								disabled: zoomMode === "manual" && manualZoom === 1,
 								"aria-label": copy.resetAria,
 								title: copy.resetTitle,
 								onClick: resetZoom,
-								children: copy.reset
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									style: styles$2.controlContent,
+									children: copy.reset
+								})
 							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								style: {
-									...styles$1.zoomButton,
-									background: zoomMode === "fit-view" ? "color-mix(in srgb, var(--ui-accent, #0ea5e9) 18%, transparent)" : styles$1.zoomButton.background
+									...styles$2.zoomButton,
+									background: zoomMode === "fit-view" ? "color-mix(in srgb, var(--ui-accent, #0ea5e9) 18%, transparent)" : styles$2.zoomButton.background
 								},
 								"aria-label": copy.fitFrameAria,
 								"aria-pressed": zoomMode === "fit-view",
@@ -1192,13 +1419,16 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 									});
 								},
 								"data-openpencil-fit-view": "true",
-								children: copy.fitFrame
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									style: styles$2.controlContent,
+									children: copy.fitFrame
+								})
 							}),
 							/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 								type: "button",
 								style: {
-									...styles$1.zoomButton,
-									background: fitContent ? "color-mix(in srgb, var(--ui-accent, #0ea5e9) 18%, transparent)" : styles$1.zoomButton.background
+									...styles$2.zoomButton,
+									background: fitContent ? "color-mix(in srgb, var(--ui-accent, #0ea5e9) 18%, transparent)" : styles$2.zoomButton.background
 								},
 								"aria-label": fitContent ? copy.restoreCardAria : copy.fitContentAria,
 								"aria-pressed": fitContent,
@@ -1212,14 +1442,17 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 									});
 								},
 								"data-openpencil-card-height-toggle": "true",
-								children: fitContent ? copy.restoreCard : copy.fitContent
+								children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+									style: styles$2.controlContent,
+									children: fitContent ? copy.restoreCard : copy.fitContent
+								})
 							})
 						]
 					}),
 					frames.length > 1 ? /* @__PURE__ */ (0, react_jsx_runtime.jsxs)(react_jsx_runtime.Fragment, { children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 						type: "button",
 						style: {
-							...styles$1.arrow,
+							...styles$2.arrow,
 							opacity: currentIndex === 0 ? .42 : 1
 						},
 						disabled: currentIndex === 0,
@@ -1228,11 +1461,14 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 						onClick: () => {
 							select(currentIndex - 1);
 						},
-						children: "‹"
+						children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+							style: styles$2.controlContent,
+							children: "‹"
+						})
 					}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("button", {
 						type: "button",
 						style: {
-							...styles$1.arrow,
+							...styles$2.arrow,
 							opacity: currentIndex === frames.length - 1 ? .42 : 1
 						},
 						disabled: currentIndex === frames.length - 1,
@@ -1241,32 +1477,35 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 						onClick: () => {
 							select(currentIndex + 1);
 						},
-						children: "›"
+						children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+							style: styles$2.controlContent,
+							children: "›"
+						})
 					})] }) : null
 				]
 			}), /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
-				style: styles$1.previewShell,
+				style: styles$2.previewShell,
 				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 					ref: viewportRef,
 					style: {
-						...styles$1.mainViewport,
+						...styles$2.mainViewport,
 						display: zoomMode === "fit-view" ? "flex" : void 0,
 						alignItems: zoomMode === "fit-view" ? "center" : void 0,
 						justifyContent: zoomMode === "fit-view" ? "center" : void 0,
 						height: zoomMode === "fit-view" ? 560 : void 0,
 						maxHeight: galleryViewportMaxHeight(fitContent),
-						overflow: zoomMode === "fit-view" ? "hidden" : styles$1.mainViewport.overflow
+						overflow: zoomMode === "fit-view" ? "hidden" : styles$2.mainViewport.overflow
 					},
 					"data-openpencil-image-viewport": "true",
 					"data-card-height-mode": fitContent ? "content" : "compact",
 					"data-preview-zoom-mode": zoomMode,
 					children: failed ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
-						style: styles$1.failure,
+						style: styles$2.failure,
 						role: "status",
 						children: copy.failed
 					}) : /* @__PURE__ */ (0, react_jsx_runtime.jsx)("img", {
 						style: {
-							...styles$1.mainImage,
+							...styles$2.mainImage,
 							width: contentWidth > 0 ? contentWidth * zoom : "auto"
 						},
 						src: current.previewUrl,
@@ -1290,7 +1529,7 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 						}
 					})
 				}), frames.length > 1 ? /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", {
-					style: styles$1.counter,
+					style: styles$2.counter,
 					children: [
 						currentIndex + 1,
 						" / ",
@@ -1300,7 +1539,7 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 			})]
 		}), frames.length > 1 ? /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 			ref: stripRef,
-			style: styles$1.strip,
+			style: styles$2.strip,
 			"aria-label": copy.thumbnails,
 			"data-openpencil-frame-strip": "true",
 			children: frames.map((frame, index) => {
@@ -1312,8 +1551,8 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 					},
 					type: "button",
 					style: {
-						...styles$1.thumbnail,
-						...selected ? styles$1.thumbnailSelected : {}
+						...styles$2.thumbnail,
+						...selected ? styles$2.thumbnailSelected : {}
 					},
 					"aria-label": `${copy.showFrame} ${index + 1}: ${label}`,
 					"aria-current": selected ? "true" : void 0,
@@ -1322,7 +1561,7 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 						select(index);
 					},
 					children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("img", {
-						style: styles$1.thumbnailImage,
+						style: styles$2.thumbnailImage,
 						src: frame.previewUrl,
 						alt: "",
 						loading: "lazy"
@@ -1333,9 +1572,134 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 	});
 }
 //#endregion
+//#region src/client/selection-dock.tsx
+/** Live OpenPencil selection chip rendered above the DSH composer. */
+const OPENPENCIL_SELECTION_DOCK_LAYOUT = {
+	boxSizing: "border-box",
+	flex: "none",
+	width: "calc(100% - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))",
+	maxWidth: "calc(var(--dsh-composer-card-max-width, 780px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))",
+	margin: "0 auto"
+};
+function hasOpenPencilSelection(selection) {
+	return (selection?.selectedIds.length ?? 0) > 0;
+}
+function selectionNodeLabel(selection, locale) {
+	if (selection.selectedIds.length === 0) return locale === "zh" ? "未选择画布节点" : "No canvas node selected";
+	if (selection.selectedIds.length > 1) return locale === "zh" ? `已选择 ${selection.selectedIds.length} 个节点` : `${selection.selectedIds.length} nodes selected`;
+	const node = selection.nodes[0];
+	return node?.name ?? node?.type ?? selection.selectedIds[0];
+}
+function selectionNodeDetail(selection, locale) {
+	if (selection.selectedIds.length === 0) return locale === "zh" ? "在右侧 OpenPencil 画布中选择节点" : "Select a node on the OpenPencil canvas";
+	const node = selection.nodes[0];
+	if (selection.selectedIds.length > 1 || node === void 0) return selection.selectedIds.slice(0, 3).join(" · ");
+	const dimensions = node.width === void 0 || node.height === void 0 ? void 0 : `${Math.round(node.width)} × ${Math.round(node.height)}`;
+	return [
+		node.type,
+		dimensions,
+		node.id
+	].filter(Boolean).join(" · ");
+}
+const styles$1 = {
+	root: {
+		...OPENPENCIL_SELECTION_DOCK_LAYOUT,
+		display: "flex",
+		alignItems: "center",
+		gap: 10,
+		minHeight: 42,
+		padding: "7px 10px",
+		border: "1px solid var(--dsw-alias-border-l2)",
+		borderRadius: 9,
+		background: "var(--dsw-alias-bg-layer-1)",
+		color: "var(--dsw-alias-label-primary)"
+	},
+	icon: {
+		width: 28,
+		height: 28,
+		flex: "0 0 28px",
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		borderRadius: 7,
+		background: "var(--dsw-alias-brand-primary, #3b82f6)",
+		color: "#fff",
+		fontSize: 15
+	},
+	text: {
+		minWidth: 0,
+		display: "flex",
+		flexDirection: "column",
+		gap: 1
+	},
+	title: {
+		fontSize: 12,
+		fontWeight: 600,
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap"
+	},
+	detail: {
+		fontSize: 11,
+		color: "var(--dsw-alias-label-secondary)",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap"
+	},
+	target: {
+		marginLeft: "auto",
+		fontSize: 11,
+		color: "var(--dsw-alias-label-secondary)",
+		whiteSpace: "nowrap"
+	}
+};
+function OpenPencilSelectionDock({ sessionId, locale }) {
+	const subscribe = (0, react.useCallback)((notify) => subscribeOpenPencilSelection(String(sessionId), notify), [sessionId]);
+	const getSnapshot = (0, react.useCallback)(() => getOpenPencilSelectionSnapshot(String(sessionId)), [sessionId]);
+	const selection = (0, react.useSyncExternalStore)(subscribe, getSnapshot, getSnapshot).selection;
+	if (!hasOpenPencilSelection(selection)) return null;
+	return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
+		style: styles$1.root,
+		"data-openpencil-selection-dock": "true",
+		role: "status",
+		children: [
+			/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+				style: styles$1.icon,
+				"aria-hidden": "true",
+				children: "◇"
+			}),
+			/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", {
+				style: styles$1.text,
+				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+					style: styles$1.title,
+					children: selectionNodeLabel(selection, locale)
+				}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+					style: styles$1.detail,
+					children: selectionNodeDetail(selection, locale)
+				})]
+			}),
+			/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+				style: styles$1.target,
+				children: locale === "zh" ? "OpenPencil 修改目标" : "OpenPencil edit target"
+			})
+		]
+	});
+}
+//#endregion
+//#region src/tool-names.ts
+/** Canonical model-facing OpenPencil tool names. */
+const OPENPENCIL_RENDER_TOOL_NAME = "openpencil_render";
+/**
+* Historical render name retained only by the browser presentation layer so
+* existing conversation cards and details panels remain replayable. The host
+* deliberately does not register this alias as a model-facing tool.
+*/
+const LEGACY_DESIGN_RENDER_TOOL_NAME = "design_render";
+//#endregion
 //#region src/client/index.tsx
 /**
-* Browser presentation for `design_render`.
+* Browser presentation for `openpencil_render` and historical
+* `design_render` conversation cards.
 *
 * PNG remains the replay-safe default. When the host also grants access to
 * the source `.op`, the user can opt into one shared, read-only Web SDK
@@ -1345,7 +1709,7 @@ function FrameGallery({ frames, selectedIndex, onSelect, locale }) {
 const PRESENTATION_META_KEY = "$dshOpenPencil";
 const DESIGN_RENDER_COPY = {
 	en: {
-		designRender: "Design render",
+		designRender: "OpenPencil render",
 		error: "error",
 		rendering: "rendering…",
 		done: "done",
@@ -1375,7 +1739,7 @@ const DESIGN_RENDER_COPY = {
 		editorUnavailable: "Editable OpenPencil canvas is not available for this result."
 	},
 	zh: {
-		designRender: "设计渲染",
+		designRender: "OpenPencil 渲染",
 		error: "错误",
 		rendering: "渲染中…",
 		done: "完成",
@@ -1969,7 +2333,7 @@ function CanvasModal({ grant, onClose, locale }) {
 		})
 	});
 }
-/** Render one `design_render` tool call as a PNG-first card. */
+/** Render one OpenPencil render tool call as a PNG-first card. */
 function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en" }) {
 	const settled = "kind" in block;
 	const error = settled && block.isError;
@@ -2023,7 +2387,7 @@ function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en"
 	});
 	return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("section", {
 		style: styles.card,
-		"data-tool": "design_render",
+		"data-tool": OPENPENCIL_RENDER_TOOL_NAME,
 		"data-state": error ? "error" : running ? "running" : "success",
 		children: [
 			/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
@@ -2134,7 +2498,7 @@ function DesignRenderView({ block, openDetails, openFile, inspect, locale = "en"
 	});
 }
 /** Render the selected editable design inside DSH's resident details column. */
-function OpenPencilEditorPanel({ block, colorScheme, locale }) {
+function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }) {
 	const grant = grantOf(block);
 	if (grant?.editor === void 0 || grant.document === void 0) return /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
 		style: styles.overlay,
@@ -2143,7 +2507,8 @@ function OpenPencilEditorPanel({ block, colorScheme, locale }) {
 	return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(ManagedOpenPencilEditor, {
 		grant,
 		colorScheme,
-		locale
+		locale,
+		sessionId: String(sessionId)
 	});
 }
 /** Required client services. */
@@ -2152,7 +2517,7 @@ const inject = [
 	"theme",
 	"locale"
 ];
-/** Register the dedicated toolview for `design_render`. */
+/** Register canonical views plus a presentation-only alias for replaying historical cards. */
 function apply(ctx) {
 	const subscribeTheme = (notify) => ctx.on("theme/change", notify);
 	const getColorScheme = () => ctx.theme.getTheme().active.colorScheme;
@@ -2175,23 +2540,41 @@ function apply(ctx) {
 			locale
 		});
 	};
-	ctx.slots.inject("tool.call.toolview", () => ctx.slots.register({
-		name: "tool.call.toolview",
-		key: "design_render"
-	}, HostSyncedDesignRenderView));
-	ctx.slots.inject("tool.details.toolview", () => ctx.slots.register({
-		name: "tool.details.toolview",
-		key: "design_render"
-	}, HostSyncedOpenPencilEditorPanel));
+	const HostSyncedOpenPencilSelectionDock = (props) => {
+		const locale = (0, react.useSyncExternalStore)(subscribeLocale, getLocale, getLocale);
+		return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(OpenPencilSelectionDock, {
+			...props,
+			locale
+		});
+	};
+	for (const toolName of [OPENPENCIL_RENDER_TOOL_NAME, LEGACY_DESIGN_RENDER_TOOL_NAME]) {
+		ctx.slots.inject("tool.call.toolview", () => ctx.slots.register({
+			name: "tool.call.toolview",
+			key: toolName
+		}, HostSyncedDesignRenderView));
+		ctx.slots.inject("tool.details.toolview", () => ctx.slots.register({
+			name: "tool.details.toolview",
+			key: toolName
+		}, HostSyncedOpenPencilEditorPanel));
+	}
+	ctx.slots.inject("conversation.input.dock", () => ctx.slots.register({
+		name: "conversation.input.dock",
+		id: "openpencil-selection",
+		order: 30
+	}, HostSyncedOpenPencilSelectionDock));
 }
 //#endregion
 exports.DesignRenderView = DesignRenderView;
 exports.GALLERY_COMPACT_MAX_HEIGHT = GALLERY_COMPACT_MAX_HEIGHT;
+exports.GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT = GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT;
 exports.GALLERY_TOOLBAR_CONTROL_HEIGHT = GALLERY_TOOLBAR_CONTROL_HEIGHT;
 exports.GALLERY_TOOLBAR_CONTROL_LAYOUT = GALLERY_TOOLBAR_CONTROL_LAYOUT;
 exports.GALLERY_ZOOM_MAX = GALLERY_ZOOM_MAX;
 exports.GALLERY_ZOOM_MIN = GALLERY_ZOOM_MIN;
 exports.GALLERY_ZOOM_STEP = GALLERY_ZOOM_STEP;
+exports.LEGACY_DESIGN_RENDER_TOOL_NAME = LEGACY_DESIGN_RENDER_TOOL_NAME;
+exports.OPENPENCIL_RENDER_TOOL_NAME = OPENPENCIL_RENDER_TOOL_NAME;
+exports.OPENPENCIL_SELECTION_DOCK_LAYOUT = OPENPENCIL_SELECTION_DOCK_LAYOUT;
 exports.OpenPencilEditorPanel = OpenPencilEditorPanel;
 exports.PRESENTATION_META_KEY = PRESENTATION_META_KEY;
 exports.apply = apply;
@@ -2199,6 +2582,8 @@ exports.calculateGalleryFitViewZoom = calculateGalleryFitViewZoom;
 exports.claimCanvas = claimCanvas;
 exports.claimEditor = claimEditor;
 exports.clampGalleryZoom = clampGalleryZoom;
+exports.clearOpenPencilSelection = clearOpenPencilSelection;
+exports.closeManagedEditorLaunch = closeManagedEditorLaunch;
 exports.confirmEditorClose = confirmEditorClose;
 exports.designRenderCopy = designRenderCopy;
 exports.editorControlUrl = editorControlUrl;
@@ -2218,15 +2603,25 @@ exports.galleryViewportMaxHeight = galleryViewportMaxHeight;
 exports.galleryZoomCommandTarget = galleryZoomCommandTarget;
 exports.galleryZoomPercent = galleryZoomPercent;
 exports.galleryZoomShortcut = galleryZoomShortcut;
+exports.getOpenPencilSelectionSnapshot = getOpenPencilSelectionSnapshot;
 exports.grantOf = grantOf;
+exports.hasOpenPencilSelection = hasOpenPencilSelection;
 exports.inject = inject;
+exports.isTerminalEditorSelectionStatus = isTerminalEditorSelectionStatus;
 exports.launchManagedEditor = launchManagedEditor;
+exports.liveSelectionOf = liveSelectionOf;
 exports.loadOpenPencilSdk = loadOpenPencilSdk;
 exports.nextGalleryZoom = nextGalleryZoom;
 exports.normalizeFrameIndex = normalizeFrameIndex;
 exports.parseEditorInbound = parseEditorInbound;
 exports.prepareManagedEditor = prepareManagedEditor;
+exports.prepareManagedEditorForMount = prepareManagedEditorForMount;
+exports.publishOpenPencilSelection = publishOpenPencilSelection;
 exports.rememberEditorSuccessor = rememberEditorSuccessor;
+exports.selectionNodeDetail = selectionNodeDetail;
+exports.selectionNodeLabel = selectionNodeLabel;
 exports.sizeCanvasForDisplay = sizeCanvasForDisplay;
+exports.startEditorSelectionPolling = startEditorSelectionPolling;
+exports.subscribeOpenPencilSelection = subscribeOpenPencilSelection;
 
 return module.exports; } });

--- a/lib/client/details-compat.d.ts
+++ b/lib/client/details-compat.d.ts
@@ -1,0 +1,28 @@
+/** Compatibility boundary for DSH builds before the keyed Tool details seam. */
+import type { ToolCallViewProps } from '@deepseek-ai/dsh-client-ui-tool/client';
+import type { DetailsToolOwnerProps } from '@deepseek-ai/dsh-client-ui-conversation/client';
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots';
+/**
+ * rc.2 does not declare this slot. Declaring the same contract locally keeps
+ * the plugin type-safe on rc.2 and is identical to the declaration shipped by
+ * newer DSH builds. At runtime `slots.inject()` waits while a slot is absent,
+ * so no registration is attempted until a supporting DSH host declares it.
+ */
+declare module '@deepseek-ai/dsh-client-ui-slots' {
+    interface SlotMap {
+        'tool.details.toolview': {
+            kind: 'keyed';
+            scope: 'session';
+            owner: DetailsToolOwnerProps;
+        };
+    }
+}
+/** Details props without importing a symbol absent from stock rc.2. */
+export type CompatibleToolDetailsViewProps = PropsRuntime<'tool.details.toolview'>;
+/** Call props with the additive newer-DSH sidebar capability. */
+export type CompatibleToolCallViewProps = ToolCallViewProps & {
+    openDetails?: (() => void) | undefined;
+};
+export type OpenPencilEditorSurface = 'details' | 'modal';
+/** Prefer the native resident details panel and otherwise open our own modal. */
+export declare function requestOpenPencilEditor(openDetails: (() => void) | undefined, openModal: () => void): OpenPencilEditorSurface;

--- a/lib/client/details-compat.js
+++ b/lib/client/details-compat.js
@@ -1,0 +1,10 @@
+/** Compatibility boundary for DSH builds before the keyed Tool details seam. */
+/** Prefer the native resident details panel and otherwise open our own modal. */
+export function requestOpenPencilEditor(openDetails, openModal) {
+    if (openDetails !== undefined) {
+        openDetails();
+        return 'details';
+    }
+    openModal();
+    return 'modal';
+}

--- a/lib/client/selection-polling.d.ts
+++ b/lib/client/selection-polling.d.ts
@@ -1,0 +1,24 @@
+/** Lifecycle-safe polling for the optional OpenPencil live-selection endpoint. */
+export interface SelectionPollTimer {
+    schedule(callback: () => void, delayMs: number): unknown;
+    cancel(handle: unknown): void;
+}
+export interface EditorSelectionPollingOptions {
+    url: string;
+    onValue(value: unknown): void;
+    onStop(): void;
+    fetcher?: typeof fetch;
+    intervalMs?: number;
+    timer?: SelectionPollTimer;
+}
+/** Client failures other than retry-oriented HTTP statuses cannot recover by polling. */
+export declare function isTerminalEditorSelectionStatus(status: number): boolean;
+/**
+ * Start one immediate poll followed by non-overlapping delayed polls.
+ *
+ * The returned cleanup is idempotent, aborts an in-flight request, cancels the
+ * pending timer, and invokes `onStop` exactly once. Terminal HTTP responses
+ * use the same cleanup path; network errors and retryable statuses schedule a
+ * later attempt without disrupting the editor itself.
+ */
+export declare function startEditorSelectionPolling(options: EditorSelectionPollingOptions): () => void;

--- a/lib/client/selection-polling.js
+++ b/lib/client/selection-polling.js
@@ -1,0 +1,79 @@
+/** Lifecycle-safe polling for the optional OpenPencil live-selection endpoint. */
+const DEFAULT_INTERVAL_MS = 400;
+const DEFAULT_TIMER = {
+    schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+    cancel: handle => { clearTimeout(handle); },
+};
+/** Client failures other than retry-oriented HTTP statuses cannot recover by polling. */
+export function isTerminalEditorSelectionStatus(status) {
+    return status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429;
+}
+/**
+ * Start one immediate poll followed by non-overlapping delayed polls.
+ *
+ * The returned cleanup is idempotent, aborts an in-flight request, cancels the
+ * pending timer, and invokes `onStop` exactly once. Terminal HTTP responses
+ * use the same cleanup path; network errors and retryable statuses schedule a
+ * later attempt without disrupting the editor itself.
+ */
+export function startEditorSelectionPolling(options) {
+    const fetcher = options.fetcher ?? fetch;
+    const timer = options.timer ?? DEFAULT_TIMER;
+    const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    let stopped = false;
+    let timerHandle;
+    let requestAbort;
+    const stop = () => {
+        if (stopped)
+            return;
+        stopped = true;
+        if (timerHandle !== undefined) {
+            timer.cancel(timerHandle);
+            timerHandle = undefined;
+        }
+        requestAbort?.abort();
+        requestAbort = undefined;
+        options.onStop();
+    };
+    const schedule = () => {
+        if (stopped)
+            return;
+        timerHandle = timer.schedule(() => {
+            timerHandle = undefined;
+            void poll();
+        }, intervalMs);
+    };
+    const poll = async () => {
+        if (stopped)
+            return;
+        const abort = new AbortController();
+        requestAbort = abort;
+        try {
+            const response = await fetcher(options.url, {
+                credentials: 'same-origin',
+                signal: abort.signal,
+            });
+            if (stopped)
+                return;
+            if (isTerminalEditorSelectionStatus(response.status)) {
+                stop();
+                return;
+            }
+            if (response.ok) {
+                const value = await response.json();
+                if (!stopped)
+                    options.onValue(value);
+            }
+        }
+        catch {
+            // Selection is an enhancement. Transient transport failures retry later.
+        }
+        finally {
+            if (requestAbort === abort)
+                requestAbort = undefined;
+            schedule();
+        }
+    };
+    void poll();
+    return stop;
+}

--- a/lib/client/selection-store.d.ts
+++ b/lib/client/selection-store.d.ts
@@ -1,0 +1,26 @@
+/** Page-local live selection store shared by the sidebar and conversation. */
+export interface OpenPencilNodeSelection {
+    id: string;
+    type?: string;
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+}
+export interface OpenPencilLiveSelection {
+    sourcePath: string;
+    activePageId: string;
+    selectedIds: string[];
+    nodes: OpenPencilNodeSelection[];
+    updatedAt: number;
+}
+export interface OpenPencilSelectionStoreSnapshot {
+    revision: number;
+    selection?: OpenPencilLiveSelection;
+}
+export declare function liveSelectionOf(value: unknown): OpenPencilLiveSelection | undefined;
+export declare function publishOpenPencilSelection(sessionId: string, selection: OpenPencilLiveSelection): void;
+export declare function clearOpenPencilSelection(sessionId: string, sourcePath?: string): void;
+export declare function subscribeOpenPencilSelection(sessionId: string, listener: () => void): () => void;
+export declare function getOpenPencilSelectionSnapshot(sessionId: string): OpenPencilSelectionStoreSnapshot;

--- a/lib/client/selection-store.js
+++ b/lib/client/selection-store.js
@@ -1,0 +1,85 @@
+/** Page-local live selection store shared by the sidebar and conversation. */
+const stores = new Map();
+const listeners = new Map();
+const EMPTY_SELECTION_STORE_SNAPSHOT = Object.freeze({ revision: 0 });
+function isRecord(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function finite(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+function nodeOf(value) {
+    if (!isRecord(value) || typeof value.id !== 'string' || value.id.length === 0)
+        return undefined;
+    return {
+        id: value.id,
+        ...(typeof value.type === 'string' && value.type.length > 0 ? { type: value.type } : {}),
+        ...(typeof value.name === 'string' && value.name.length > 0 ? { name: value.name } : {}),
+        ...(finite(value.x) === undefined ? {} : { x: finite(value.x) }),
+        ...(finite(value.y) === undefined ? {} : { y: finite(value.y) }),
+        ...(finite(value.width) === undefined ? {} : { width: finite(value.width) }),
+        ...(finite(value.height) === undefined ? {} : { height: finite(value.height) }),
+    };
+}
+export function liveSelectionOf(value) {
+    if (!isRecord(value) || typeof value.sourcePath !== 'string' || value.sourcePath.length === 0)
+        return undefined;
+    return {
+        sourcePath: value.sourcePath,
+        activePageId: typeof value.activePageId === 'string' ? value.activePageId : '',
+        selectedIds: Array.isArray(value.selectedIds)
+            ? value.selectedIds.filter((id) => typeof id === 'string' && id.length > 0)
+            : [],
+        nodes: Array.isArray(value.nodes)
+            ? value.nodes.map(nodeOf).filter((node) => node !== undefined)
+            : [],
+        updatedAt: finite(value.updatedAt) ?? Date.now(),
+    };
+}
+function sameSelection(a, b) {
+    if (a === undefined || b === undefined)
+        return a === b;
+    return a.sourcePath === b.sourcePath
+        && a.activePageId === b.activePageId
+        && JSON.stringify(a.selectedIds) === JSON.stringify(b.selectedIds)
+        && JSON.stringify(a.nodes) === JSON.stringify(b.nodes);
+}
+export function publishOpenPencilSelection(sessionId, selection) {
+    const current = stores.get(sessionId) ?? { revision: 0 };
+    if (sameSelection(current.selection, selection))
+        return;
+    stores.set(sessionId, { revision: current.revision + 1, selection });
+    for (const listener of listeners.get(sessionId) ?? [])
+        listener();
+}
+export function clearOpenPencilSelection(sessionId, sourcePath) {
+    const current = stores.get(sessionId);
+    if (current === undefined)
+        return;
+    if (current.selection === undefined)
+        return;
+    if (sourcePath !== undefined && current.selection.sourcePath !== sourcePath)
+        return;
+    stores.set(sessionId, { revision: current.revision + 1 });
+    for (const listener of listeners.get(sessionId) ?? [])
+        listener();
+}
+export function subscribeOpenPencilSelection(sessionId, listener) {
+    let scoped = listeners.get(sessionId);
+    if (scoped === undefined) {
+        scoped = new Set();
+        listeners.set(sessionId, scoped);
+    }
+    scoped.add(listener);
+    return () => {
+        scoped?.delete(listener);
+        if (scoped?.size === 0)
+            listeners.delete(sessionId);
+    };
+}
+export function getOpenPencilSelectionSnapshot(sessionId) {
+    // useSyncExternalStore requires referentially stable snapshots while the
+    // underlying state is unchanged. Returning a new empty object here causes
+    // React to enter an update loop before the first selection poll completes.
+    return stores.get(sessionId) ?? EMPTY_SELECTION_STORE_SNAPSHOT;
+}

--- a/lib/design-tools.d.ts
+++ b/lib/design-tools.d.ts
@@ -1,0 +1,21 @@
+/** Model-facing tools that directly drive the active OpenPencil canvas. */
+import { type JsonValue } from '@deepseek-ai/dsh-tools';
+import type { EditorHostController } from './editor-host.js';
+/** Read the exact selection the user currently has on the editable canvas. */
+export declare function createDesignSelectionTool(editorHost: EditorHostController): import("@deepseek-ai/dsh-tools").ToolDefinition;
+export interface DesignCreateArgs {
+    path: string;
+    operations: string;
+    pageId?: string;
+    canvasWidth?: number;
+    postProcess?: boolean;
+}
+/** Apply one transactional OpenPencil batch program to generate design nodes. */
+export declare function createDesignCreateTool(editorHost: EditorHostController): import("@deepseek-ai/dsh-tools").ToolDefinition;
+export interface DesignEditArgs {
+    path: string;
+    nodeId?: string;
+    changes: Record<string, JsonValue>;
+}
+/** Patch one explicit node, or the single node the user selected. */
+export declare function createDesignEditTool(editorHost: EditorHostController): import("@deepseek-ai/dsh-tools").ToolDefinition;

--- a/lib/design-tools.js
+++ b/lib/design-tools.js
@@ -1,0 +1,213 @@
+/** Model-facing tools that directly drive the active OpenPencil canvas. */
+import { defineTool } from '@deepseek-ai/dsh-tools';
+import { resolveInputFile } from './renderer.js';
+import { OPENPENCIL_CREATE_TOOL_NAME, OPENPENCIL_EDIT_TOOL_NAME, OPENPENCIL_SELECTION_TOOL_NAME, } from './tool-names.js';
+const MAX_OPERATIONS_LENGTH = 256 * 1024;
+function sessionWorkspace(exec) {
+    return exec.agent?.session.header.cwd ?? process.cwd();
+}
+async function expectedSource(path, exec) {
+    return path === undefined ? undefined : resolveInputFile(path, sessionWorkspace(exec));
+}
+function ownerSessionId(exec) {
+    return exec.agent === undefined ? undefined : String(exec.agent.id);
+}
+const renderJson = (_args, value) => [{
+        type: 'text',
+        text: JSON.stringify(value, null, 2),
+    }];
+const nodeSchema = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        id: { type: 'string', required: true },
+        type: { type: 'string' },
+        name: { type: 'string' },
+        x: { type: 'number' },
+        y: { type: 'number' },
+        width: { type: 'number' },
+        height: { type: 'number' },
+    },
+};
+const selectionProperties = {
+    sourcePath: { type: 'string', required: true },
+    activePageId: { type: 'string', required: true },
+    selectedIds: { type: 'array', items: { type: 'string' }, required: true },
+    nodes: { type: 'array', items: nodeSchema, required: true },
+    count: { type: 'integer', required: true },
+    updatedAt: { type: 'integer', required: true },
+};
+function selectionResult(selection) {
+    return { ...selection, count: selection.selectedIds.length };
+}
+/** Read the exact selection the user currently has on the editable canvas. */
+export function createDesignSelectionTool(editorHost) {
+    return defineTool({
+        name: OPENPENCIL_SELECTION_TOOL_NAME,
+        description: 'Read the current selection from the live OpenPencil sidebar canvas. '
+            + 'Use this before modifying a node. Returns selected node ids, names, types, bounds, and the active page. '
+            + 'The editable sidebar must already be open. If path is supplied, the tool refuses to target a different canvas.',
+        parameters: {
+            path: { type: 'string', description: 'Optional .op path used to assert which live editor is being read.' },
+        },
+        output: {
+            schema: {
+                type: 'object', additionalProperties: false, properties: selectionProperties,
+            },
+            render: renderJson,
+        },
+        async execute(args, exec) {
+            const sourcePath = await expectedSource(args.path, exec);
+            const selection = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: ownerSessionId(exec), signal: exec.signal });
+            return selectionResult(selection);
+        },
+        presentCall: () => ({ card: 'generic', title: 'Read OpenPencil selection', kind: 'read' }),
+    });
+}
+/** Apply one transactional OpenPencil batch program to generate design nodes. */
+export function createDesignCreateTool(editorHost) {
+    return defineTool({
+        name: OPENPENCIL_CREATE_TOOL_NAME,
+        description: 'Generate or restructure design nodes directly on the active OpenPencil canvas using one transactional batch_design program. '
+            + 'The editable sidebar must already be open. Use concise newline-separated operations: '
+            + 'I(parentId, nodeJson) inserts, U(nodeId, patchJson) updates, D(nodeId) deletes, '
+            + 'M(nodeId,parentId,index) moves, C(nodeId,parentId,overrides) clones, and R(nodeId,nodeJson) replaces. '
+            + 'All operations apply together or none apply. The canvas updates live but remains unsaved until the sidebar Save action.',
+        parameters: {
+            path: { type: 'string', required: true, description: 'The .op path used to bind this write to the intended live editor.' },
+            operations: {
+                type: 'string', required: true,
+                description: 'Newline-separated batch_design operations, for example I("page-id", {"type":"frame","id":"hero","name":"Hero","x":0,"y":0,"width":1200,"height":800}).',
+            },
+            pageId: { type: 'string', description: 'Optional page id. Defaults to the live editor active page.' },
+            canvasWidth: { type: 'number', description: 'Optional canvas width hint for post-processing.' },
+            postProcess: { type: 'boolean', description: 'Run OpenPencil post-processing after the batch. Default false.' },
+        },
+        output: {
+            schema: {
+                type: 'object', additionalProperties: false,
+                properties: {
+                    ...selectionProperties,
+                    applied: { type: 'boolean', const: true, required: true },
+                    dirty: { type: 'boolean', const: true, required: true },
+                    saved: { type: 'boolean', const: false, required: true },
+                    result: { type: 'object', additionalProperties: true },
+                    note: { type: 'string', required: true },
+                },
+            },
+            render: renderJson,
+        },
+        async execute(args, exec) {
+            if (args.operations.trim().length === 0)
+                throw new Error(`${OPENPENCIL_CREATE_TOOL_NAME}: operations must not be empty`);
+            if (args.operations.length > MAX_OPERATIONS_LENGTH)
+                throw new Error(`${OPENPENCIL_CREATE_TOOL_NAME}: operations are too large`);
+            const sourcePath = await expectedSource(args.path, exec);
+            const owner = ownerSessionId(exec);
+            const before = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal });
+            const result = await editorHost.callActiveMcp('batch_design', {
+                operations: args.operations,
+                ...(args.pageId !== undefined && args.pageId.length > 0
+                    ? { pageId: args.pageId }
+                    : before.activePageId === '' ? {} : { pageId: before.activePageId }),
+                ...(args.canvasWidth === undefined ? {} : { canvasWidth: args.canvasWidth }),
+                ...(args.postProcess === undefined ? {} : { postProcess: args.postProcess }),
+            }, { sourcePath, ownerSessionId: owner, signal: exec.signal });
+            const selection = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal });
+            return {
+                ...selectionResult(selection),
+                applied: true,
+                dirty: true,
+                saved: false,
+                ...(typeof result.value === 'object' && result.value !== null && !Array.isArray(result.value)
+                    ? { result: result.value }
+                    : {}),
+                note: 'Applied to the live OpenPencil canvas. Use Save in the sidebar to persist the .op file.',
+            };
+        },
+        presentCall: () => ({ card: 'generic', title: 'Generate on OpenPencil canvas', kind: 'execute' }),
+    });
+}
+/** Patch one explicit node, or the single node the user selected. */
+export function createDesignEditTool(editorHost) {
+    return defineTool({
+        name: OPENPENCIL_EDIT_TOOL_NAME,
+        description: 'Modify one node directly on the active OpenPencil canvas. '
+            + 'When nodeId is omitted, this tool targets the single node currently selected by the user; '
+            + 'it refuses an empty or multi-selection instead of guessing. Pass rich OpenPencil node fields in changes, '
+            + 'for example content, name, x, y, width, height, fill, fontSize, padding, layout, or opacity. '
+            + 'The canvas updates live but remains unsaved until the sidebar Save action.',
+        parameters: {
+            path: { type: 'string', required: true, description: 'The .op path used to bind this write to the intended live editor.' },
+            nodeId: { type: 'string', description: 'Explicit target node id. Omit to use the one selected canvas node.' },
+            changes: {
+                type: 'object', additionalProperties: true, required: true,
+                description: 'Shallow OpenPencil node patch. Rich canonical fields are preserved.',
+            },
+        },
+        output: {
+            schema: {
+                type: 'object', additionalProperties: false,
+                properties: {
+                    ...selectionProperties,
+                    applied: { type: 'boolean', const: true, required: true },
+                    dirty: { type: 'boolean', const: true, required: true },
+                    saved: { type: 'boolean', const: false, required: true },
+                    targetNodeId: { type: 'string', required: true },
+                    targetSource: { type: 'string', enum: ['explicit', 'selection'], required: true },
+                    result: { type: 'object', additionalProperties: true },
+                    note: { type: 'string', required: true },
+                },
+            },
+            render: renderJson,
+        },
+        async execute(args, exec) {
+            if (Object.keys(args.changes).length === 0)
+                throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: changes must not be empty`);
+            const sourcePath = await expectedSource(args.path, exec);
+            const owner = ownerSessionId(exec);
+            const before = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal });
+            const explicit = args.nodeId?.trim();
+            let targetNodeId;
+            let targetSource;
+            if (explicit !== undefined && explicit.length > 0) {
+                if (!before.selectedIds.includes(explicit)) {
+                    throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: nodeId ${explicit} is not in the current canvas selection`);
+                }
+                targetNodeId = explicit;
+                targetSource = 'explicit';
+            }
+            else {
+                if (before.selectedIds.length === 0) {
+                    throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: no canvas node is selected; select one in OpenPencil or pass nodeId`);
+                }
+                if (before.selectedIds.length !== 1) {
+                    throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: ${before.selectedIds.length} nodes are selected; pass nodeId to choose one`);
+                }
+                targetNodeId = before.selectedIds[0];
+                targetSource = 'selection';
+            }
+            const result = await editorHost.callActiveMcp('update_node', {
+                nodeId: targetNodeId,
+                data: args.changes,
+                ...(before.activePageId === '' ? {} : { pageId: before.activePageId }),
+            }, { sourcePath, ownerSessionId: owner, signal: exec.signal });
+            const selection = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal });
+            return {
+                ...selectionResult(selection),
+                applied: true,
+                dirty: true,
+                saved: false,
+                targetNodeId,
+                targetSource,
+                ...(typeof result.value === 'object' && result.value !== null && !Array.isArray(result.value)
+                    ? { result: result.value }
+                    : {}),
+                note: 'Applied to the live OpenPencil canvas. Use Save in the sidebar to persist the .op file.',
+            };
+        },
+        presentCall: (args) => ({
+            card: 'generic', title: args.nodeId === undefined ? 'Edit selected OpenPencil node' : `Edit OpenPencil node ${args.nodeId}`, kind: 'execute',
+        }),
+    });
+}

--- a/lib/editor-host.d.ts
+++ b/lib/editor-host.d.ts
@@ -1,10 +1,18 @@
 /** Lazy managed OpenPencil editor sessions for the DSH details panel. */
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { type OpenPencilMcpResult, type OpenPencilSelectionSnapshot } from './mcp-client.js';
 export declare const EDITOR_ROUTE_PREFIX = "/_dsh/dsh-openpencil/editor";
 export interface EditorGrant {
     enabled: true;
     launchUrl: string;
     refreshUrl: string;
+}
+export type OpenPencilLiveTool = 'get_selection' | 'update_node' | 'batch_design';
+export interface ActiveMcpCallOptions {
+    /** Refuse to drive a different transcript card's live editor. */
+    sourcePath?: string;
+    ownerSessionId?: string;
+    signal?: AbortSignal;
 }
 /** Locate the GUI-free managed host used by op-vscode. */
 export declare function findEditorHostBinary(): string | undefined;
@@ -20,4 +28,11 @@ export declare class EditorHostController {
     grantFor(sourcePath: string | undefined, sourceSha256: string | undefined): EditorGrant | undefined;
     handle(req: IncomingMessage, res: ServerResponse): Promise<void>;
     dispose(): Promise<void>;
+    /** Current live editor selection, suitable for Agent context and UI chips. */
+    getActiveSelection(options?: ActiveMcpCallOptions): Promise<OpenPencilSelectionSnapshot>;
+    /**
+     * Drive one allowlisted first-party MCP tool on the currently visible
+     * editor. The managed daemon token never crosses this controller boundary.
+     */
+    callActiveMcp(tool: OpenPencilLiveTool, args: Record<string, unknown>, options?: ActiveMcpCallOptions): Promise<OpenPencilMcpResult>;
 }

--- a/lib/editor-host.js
+++ b/lib/editor-host.js
@@ -5,6 +5,8 @@ import { lstat, open, rename, rm } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { homedir } from 'node:os';
 import { basename, delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { callOpenPencilMcp, getOpenPencilMcpVersion, selectionSnapshotFromMcp, } from './mcp-client.js';
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js';
 export const EDITOR_ROUTE_PREFIX = '/_dsh/dsh-openpencil/editor';
 const CAPABILITY_TTL_MS = 2 * 60 * 60 * 1000;
 const CAPABILITY_REFRESH_TTL_MS = 24 * 60 * 60 * 1000;
@@ -57,6 +59,20 @@ function json(res, status, value) {
     res.setHeader('cache-control', 'no-store');
     res.setHeader('x-content-type-options', 'nosniff');
     res.end(body);
+}
+async function waitForResponseFinish(res) {
+    if (res.writableFinished)
+        return true;
+    await new Promise(resolveFinished => {
+        const finish = () => {
+            res.off('finish', finish);
+            res.off('close', finish);
+            resolveFinished();
+        };
+        res.once('finish', finish);
+        res.once('close', finish);
+    });
+    return res.writableFinished;
 }
 function errorMessage(error) {
     return error instanceof Error ? error.message : String(error);
@@ -266,16 +282,39 @@ async function waitForEditorReady(baseUrl) {
     }
     throw new Error(`OpenPencil editor web bundle was not ready${last === '' ? '' : `: ${last}`}`);
 }
-async function stopChild(child) {
+const stoppingChildren = new WeakMap();
+function stopChild(child) {
+    const current = stoppingChildren.get(child);
+    if (current !== undefined)
+        return current;
     if (child.exitCode !== null || child.killed)
-        return;
-    child.stdin.end();
-    const closed = await Promise.race([
-        new Promise(resolveClosed => child.once('close', () => { resolveClosed(true); })),
-        new Promise(resolveTimeout => setTimeout(() => { resolveTimeout(false); }, STOP_TIMEOUT_MS)),
-    ]);
-    if (!closed && child.exitCode === null)
-        child.kill('SIGKILL');
+        return Promise.resolve();
+    const stopping = (async () => {
+        if (!child.stdin.writableEnded)
+            child.stdin.end();
+        const closed = await new Promise(resolveClosed => {
+            let settled = false;
+            const finish = (value) => {
+                if (settled)
+                    return;
+                settled = true;
+                clearTimeout(timer);
+                child.off('close', onClose);
+                resolveClosed(value);
+            };
+            const onClose = () => { finish(true); };
+            const timer = setTimeout(() => { finish(false); }, STOP_TIMEOUT_MS);
+            child.once('close', onClose);
+        });
+        if (!closed && child.exitCode === null)
+            child.kill('SIGKILL');
+    })();
+    stoppingChildren.set(child, stopping);
+    void stopping.finally(() => {
+        if (stoppingChildren.get(child) === stopping)
+            stoppingChildren.delete(child);
+    });
+    return stopping;
 }
 async function atomicWriteDocument(path, text) {
     const bytes = Buffer.from(text);
@@ -314,8 +353,11 @@ async function atomicWriteDocument(path, text) {
 export class EditorHostController {
     binary = findEditorHostBinary();
     #routeRefs = 0;
+    #routeGeneration = 0;
     #editorKey;
     #sessions = new Map();
+    #pendingChildren = new Set();
+    #launchQueue = Promise.resolve();
     constructor(masterKey) {
         this.#editorKey = deriveEditorKey(masterKey);
     }
@@ -361,9 +403,26 @@ export class EditorHostController {
             const refresh = new RegExp(`^${EDITOR_ROUTE_PREFIX}/([A-Za-z0-9_.-]+)/refresh$`).exec(url.pathname);
             const legacyRefresh = url.pathname === `${EDITOR_ROUTE_PREFIX}/refresh`;
             const save = new RegExp(`^${EDITOR_ROUTE_PREFIX}/session/([A-Za-z0-9_-]+)/save$`).exec(url.pathname);
+            const selection = new RegExp(`^${EDITOR_ROUTE_PREFIX}/session/([A-Za-z0-9_-]+)/selection$`).exec(url.pathname);
             const close = new RegExp(`^${EDITOR_ROUTE_PREFIX}/session/([A-Za-z0-9_-]+)$`).exec(url.pathname);
             if (launch !== null && req.method === 'POST') {
-                await this.#launch(launch[1], requestOrigin(req), res);
+                const body = await readRequestBody(req);
+                let ownerSessionId;
+                if (body.length > 0) {
+                    try {
+                        const value = JSON.parse(body.toString('utf8'));
+                        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+                            const candidate = value.sessionId;
+                            if (typeof candidate === 'string' && candidate.length > 0 && candidate.length <= 256)
+                                ownerSessionId = candidate;
+                        }
+                    }
+                    catch {
+                        throw new HttpError(400, 'editor launch request is not valid JSON');
+                    }
+                }
+                const routeGeneration = this.#routeGeneration;
+                await this.#serializeLaunch(() => this.#launch(launch[1], requestOrigin(req), res, routeGeneration, ownerSessionId));
                 return;
             }
             if (refresh !== null && req.method === 'POST') {
@@ -375,11 +434,16 @@ export class EditorHostController {
             if (legacyRefresh && req.method === 'POST') {
                 requestOrigin(req);
                 await readRequestBody(req).catch(() => Buffer.alloc(0));
-                throw new HttpError(410, 'This editor card predates restart-safe editing; rerun design_render once');
+                throw new HttpError(410, `This editor card predates restart-safe editing; rerun ${OPENPENCIL_RENDER_TOOL_NAME} once`);
             }
             if (save !== null && req.method === 'POST') {
                 requestOrigin(req);
                 await this.#save(save[1], req, res);
+                return;
+            }
+            if (selection !== null && req.method === 'GET') {
+                const snapshot = await this.#selectionForSession(selection[1]);
+                json(res, 200, { ok: true, selection: snapshot });
                 return;
             }
             if (close !== null && req.method === 'DELETE') {
@@ -397,88 +461,200 @@ export class EditorHostController {
         }
     }
     async dispose() {
+        // Invalidate work accepted by the route before it was detached. Pending
+        // launches check this generation around every asynchronous startup phase,
+        // and their child is stopped here so a handshake wait cannot leak.
+        this.#routeGeneration += 1;
         const sessions = [...this.#sessions.values()];
         this.#sessions.clear();
-        await Promise.all(sessions.map(session => this.#disposeSession(session)));
+        const pending = [...this.#pendingChildren];
+        await Promise.all([
+            ...sessions.map(session => this.#disposeSession(session)),
+            ...pending.map(child => stopChild(child)),
+        ]);
     }
-    async #launch(token, origin, res) {
-        const capability = this.#openCapability(token);
-        if (Date.now() > capability.launchExpiresAt)
-            throw new HttpError(410, 'editor capability expired; rerun design_render');
-        const current = await readSourceDocument(capability.sourcePath);
-        if (sha256(current) !== capability.sourceSha256) {
-            throw new HttpError(409, 'source changed since this preview; rerun design_render before editing');
+    /** Current live editor selection, suitable for Agent context and UI chips. */
+    async getActiveSelection(options = {}) {
+        const session = this.#activeSession(options.sourcePath, options.ownerSessionId);
+        return this.#selectionFor(session, options.signal);
+    }
+    /**
+     * Drive one allowlisted first-party MCP tool on the currently visible
+     * editor. The managed daemon token never crosses this controller boundary.
+     */
+    async callActiveMcp(tool, args, options = {}) {
+        const session = this.#activeSession(options.sourcePath, options.ownerSessionId);
+        const mutating = tool === 'update_node' || tool === 'batch_design';
+        if ('filePath' in args || 'sourceFilePath' in args || 'source_file_path' in args) {
+            throw new Error('OpenPencil live tools cannot target a filesystem path through MCP arguments');
         }
-        const binary = this.binary;
-        if (binary === undefined)
-            throw new HttpError(503, 'OpenPencil editor host binary is unavailable');
-        // The details panel hosts one editor. Retire an earlier daemon before a
-        // successor starts so stale transcript cards cannot retain authority.
-        const old = [...this.#sessions.values()];
-        this.#sessions.clear();
-        await Promise.all(old.map(session => this.#disposeSession(session)));
-        const env = { ...process.env };
-        const sourceRoot = sourceRootForBinary(binary);
-        if (sourceRoot !== undefined) {
-            env.OPENPENCIL_WEB_BUNDLE_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'pkg');
-            env.OPENPENCIL_CANVASKIT_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'assets', 'canvaskit');
+        if (mutating && (session.saving || session.mutating)) {
+            throw new Error('OpenPencil editor is already applying or saving another change');
         }
-        const child = spawn(binary, [
-            '--serve-web', '--managed', '--port', '0', '--file', capability.sourcePath,
-            '--allow-origin', origin,
-        ], { stdio: ['pipe', 'pipe', 'pipe'], env });
-        let diagnostics = '';
-        child.stderr.on('data', (chunk) => {
-            if (diagnostics.length < MAX_DIAGNOSTIC_BYTES) {
-                diagnostics += chunk.toString('utf8').slice(0, MAX_DIAGNOSTIC_BYTES - diagnostics.length);
-            }
-        });
-        let handshake;
+        if (mutating)
+            session.mutating = true;
         try {
-            handshake = await waitForHandshake(child, () => diagnostics.trim());
-            const baseUrl = `http://127.0.0.1:${handshake.port}`;
-            await waitForEditorReady(baseUrl);
-            const id = randomBytes(24).toString('base64url');
-            const session = {
-                id,
-                sourcePath: capability.sourcePath,
-                baselineSha256: capability.sourceSha256,
-                child,
-                iframeUrl: `${baseUrl}/?embed=vscode`,
-                daemonToken: handshake.token,
-                refreshExpiresAt: capability.refreshExpiresAt,
-                createdAt: Date.now(),
-                closed: false,
-                saving: false,
-            };
-            this.#sessions.set(id, session);
-            child.once('close', () => {
-                if (this.#sessions.get(id) === session)
-                    this.#sessions.delete(id);
-                session.closed = true;
-            });
-            json(res, 200, {
-                sessionId: id,
-                iframeUrl: session.iframeUrl,
+            let beforeVersion;
+            if (mutating) {
+                const current = await readSourceDocument(session.sourcePath);
+                if (sha256(current) !== session.baselineSha256) {
+                    throw new Error('OpenPencil source changed outside the active editor; rerender before applying Agent changes');
+                }
+                beforeVersion = await getOpenPencilMcpVersion({
+                    baseUrl: new URL(session.iframeUrl).origin,
+                    token: session.daemonToken,
+                    signal: options.signal,
+                });
+            }
+            const result = await callOpenPencilMcp({
+                baseUrl: new URL(session.iframeUrl).origin,
                 token: session.daemonToken,
-                saveUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}/save`,
-                closeUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}`,
-                docJson: current.toString('utf8'),
+                tool,
+                arguments: args,
+                signal: options.signal,
             });
+            if (beforeVersion !== undefined) {
+                const afterVersion = await getOpenPencilMcpVersion({
+                    baseUrl: new URL(session.iframeUrl).origin,
+                    token: session.daemonToken,
+                    signal: options.signal,
+                });
+                if (afterVersion <= beforeVersion) {
+                    throw new Error(`OpenPencil MCP ${tool} reported success but did not apply a document change`);
+                }
+            }
+            session.createdAt = Date.now();
+            return result;
         }
-        catch (error) {
-            await stopChild(child);
-            throw error;
+        finally {
+            if (mutating)
+                session.mutating = false;
+        }
+    }
+    async #serializeLaunch(task) {
+        const run = this.#launchQueue.then(task, task);
+        // A failed launch must not poison the lifecycle queue for later requests.
+        this.#launchQueue = run.catch(() => { });
+        await run;
+    }
+    #assertLaunchLifecycle(routeGeneration) {
+        if (routeGeneration !== this.#routeGeneration || !this.routeAvailable) {
+            throw new HttpError(410, 'editor route was unloaded during launch');
+        }
+    }
+    async #launch(token, origin, res, routeGeneration, ownerSessionId) {
+        let disconnected = res.destroyed;
+        let launchChild;
+        const onResponseClose = () => {
+            if (res.writableFinished)
+                return;
+            disconnected = true;
+            if (launchChild !== undefined)
+                void stopChild(launchChild);
+        };
+        res.once('close', onResponseClose);
+        const assertConnected = () => {
+            this.#assertLaunchLifecycle(routeGeneration);
+            if (disconnected || res.destroyed)
+                throw new HttpError(499, 'editor launch client disconnected');
+        };
+        try {
+            assertConnected();
+            const capability = this.#openCapability(token);
+            if (Date.now() > capability.launchExpiresAt)
+                throw new HttpError(410, `editor capability expired; rerun ${OPENPENCIL_RENDER_TOOL_NAME}`);
+            const current = await readSourceDocument(capability.sourcePath);
+            assertConnected();
+            if (sha256(current) !== capability.sourceSha256) {
+                throw new HttpError(409, `source changed since this preview; rerun ${OPENPENCIL_RENDER_TOOL_NAME} before editing`);
+            }
+            const binary = this.binary;
+            if (binary === undefined)
+                throw new HttpError(503, 'OpenPencil editor host binary is unavailable');
+            // The details panel hosts one editor. Retire an earlier daemon before a
+            // successor starts so stale transcript cards cannot retain authority.
+            const old = [...this.#sessions.values()];
+            this.#sessions.clear();
+            await Promise.all(old.map(session => this.#disposeSession(session)));
+            assertConnected();
+            const env = { ...process.env };
+            const sourceRoot = sourceRootForBinary(binary);
+            if (sourceRoot !== undefined) {
+                env.OPENPENCIL_WEB_BUNDLE_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'pkg');
+                env.OPENPENCIL_CANVASKIT_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'assets', 'canvaskit');
+            }
+            const child = spawn(binary, [
+                '--serve-web', '--managed', '--port', '0', '--file', capability.sourcePath,
+                '--allow-origin', origin,
+            ], { stdio: ['pipe', 'pipe', 'pipe'], env });
+            launchChild = child;
+            this.#pendingChildren.add(child);
+            let diagnostics = '';
+            child.stderr.on('data', (chunk) => {
+                if (diagnostics.length < MAX_DIAGNOSTIC_BYTES) {
+                    diagnostics += chunk.toString('utf8').slice(0, MAX_DIAGNOSTIC_BYTES - diagnostics.length);
+                }
+            });
+            try {
+                const handshake = await waitForHandshake(child, () => diagnostics.trim());
+                assertConnected();
+                const baseUrl = `http://127.0.0.1:${handshake.port}`;
+                await waitForEditorReady(baseUrl);
+                assertConnected();
+                const id = randomBytes(24).toString('base64url');
+                const session = {
+                    id,
+                    sourcePath: capability.sourcePath,
+                    ...(ownerSessionId === undefined ? {} : { ownerSessionId }),
+                    baselineSha256: capability.sourceSha256,
+                    child,
+                    iframeUrl: `${baseUrl}/?embed=vscode`,
+                    daemonToken: handshake.token,
+                    refreshExpiresAt: capability.refreshExpiresAt,
+                    createdAt: Date.now(),
+                    closed: false,
+                    saving: false,
+                    mutating: false,
+                };
+                this.#sessions.set(id, session);
+                this.#pendingChildren.delete(child);
+                child.once('close', () => {
+                    if (this.#sessions.get(id) === session)
+                        this.#sessions.delete(id);
+                    session.closed = true;
+                });
+                json(res, 200, {
+                    sessionId: id,
+                    iframeUrl: session.iframeUrl,
+                    token: session.daemonToken,
+                    saveUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}/save`,
+                    selectionUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}/selection`,
+                    closeUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}`,
+                    docJson: current.toString('utf8'),
+                });
+                if (!await waitForResponseFinish(res)) {
+                    throw new HttpError(499, 'editor launch client disconnected');
+                }
+                launchChild = undefined;
+            }
+            catch (error) {
+                this.#pendingChildren.delete(child);
+                await stopChild(child);
+                throw error;
+            }
+        }
+        finally {
+            res.off('close', onResponseClose);
         }
     }
     async #refresh(token, res) {
         const capability = this.#openCapability(token);
         const now = Date.now();
         if (now > capability.refreshExpiresAt)
-            throw new HttpError(410, 'editor capability expired; rerun design_render');
+            throw new HttpError(410, `editor capability expired; rerun ${OPENPENCIL_RENDER_TOOL_NAME}`);
         const current = await readSourceDocument(capability.sourcePath);
         if (sha256(current) !== capability.sourceSha256) {
-            throw new HttpError(409, 'source changed since this preview; rerun design_render before editing');
+            throw new HttpError(409, `source changed since this preview; rerun ${OPENPENCIL_RENDER_TOOL_NAME} before editing`);
         }
         const next = this.#sealCapability({
             ...capability,
@@ -493,8 +669,8 @@ export class EditorHostController {
         const session = this.#sessions.get(id);
         if (session === undefined || session.closed)
             throw new HttpError(410, 'editor session has ended');
-        if (session.saving)
-            throw new HttpError(409, 'another editor save is already in progress');
+        if (session.saving || session.mutating)
+            throw new HttpError(409, 'another editor change or save is already in progress');
         session.saving = true;
         try {
             const bytes = await readRequestBody(req);
@@ -555,6 +731,40 @@ export class EditorHostController {
         this.#sessions.delete(id);
         await this.#disposeSession(session);
     }
+    #activeSession(expectedSourcePath, ownerSessionId) {
+        this.#prune();
+        const sessions = [...this.#sessions.values()].filter(session => !session.closed);
+        if (sessions.length !== 1) {
+            throw new Error('No active OpenPencil editor. Render with editable=true and open “Edit in sidebar” first.');
+        }
+        const session = sessions[0];
+        if (ownerSessionId !== undefined && session.ownerSessionId !== ownerSessionId) {
+            throw new Error('The active OpenPencil editor belongs to a different DSH session');
+        }
+        if (expectedSourcePath !== undefined && resolve(expectedSourcePath) !== session.sourcePath) {
+            throw new Error(`The active OpenPencil editor is ${session.sourcePath}, not ${resolve(expectedSourcePath)}`);
+        }
+        return session;
+    }
+    async #selectionForSession(id) {
+        if (!TOKEN_PATTERN.test(id))
+            throw new HttpError(404, 'editor session not found');
+        const session = this.#sessions.get(id);
+        if (session === undefined || session.closed)
+            throw new HttpError(410, 'editor session has ended');
+        return this.#selectionFor(session);
+    }
+    async #selectionFor(session, signal) {
+        const result = await callOpenPencilMcp({
+            baseUrl: new URL(session.iframeUrl).origin,
+            token: session.daemonToken,
+            tool: 'get_selection',
+            arguments: { readDepth: 0 },
+            signal,
+        });
+        session.createdAt = Date.now();
+        return selectionSnapshotFromMcp(session.sourcePath, result.value);
+    }
     async #disposeSession(session) {
         if (session.closed)
             return;
@@ -581,7 +791,7 @@ export class EditorHostController {
         if (!token.startsWith(EDITOR_CAPABILITY_PREFIX)) {
             // Compatibility boundary for pre-fix transcript cards: their random
             // in-memory token cannot safely be recreated after a plugin reload.
-            throw new HttpError(410, 'editor capability expired; rerun design_render');
+            throw new HttpError(410, `editor capability expired; rerun ${OPENPENCIL_RENDER_TOOL_NAME}`);
         }
         if (token.length > EDITOR_CAPABILITY_MAX_LENGTH)
             throw new HttpError(404, 'editor capability not found');

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -7,7 +7,7 @@
  * registered through `ctx.effect` (or a returned disposer) so unloading the
  * plugin removes every contribution.
  *
- * The `design_render` tool never returns an ImageBlock — the DeepSeek
+ * The `openpencil_render` tool never returns an ImageBlock — the DeepSeek
  * adapter rejects image blocks anywhere in a request. The browser-only
  * envelope rides `output.presentationMeta` into `ToolCallBlock.meta`, and
  * the keyed `tool.call.toolview` client component renders a PNG-first card
@@ -15,6 +15,7 @@
  * @module @dsh-external/dsh-openpencil
  */
 import type { Context } from '@deepseek-ai/cordis';
+export { LEGACY_DESIGN_RENDER_TOOL_NAME, OPENPENCIL_CREATE_TOOL_NAME, OPENPENCIL_EDIT_TOOL_NAME, OPENPENCIL_RENDER_TOOL_NAME, OPENPENCIL_SELECTION_TOOL_NAME, OPENPENCIL_TOOL_NAMES, } from './tool-names.js';
 /** Stable plugin name (the loader entry id in cordis.patch.yml). */
 export declare const name = "@dsh-external/dsh-openpencil";
 /** Services this plugin's root fiber requires. */

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@
  * registered through `ctx.effect` (or a returned disposer) so unloading the
  * plugin removes every contribution.
  *
- * The `design_render` tool never returns an ImageBlock — the DeepSeek
+ * The `openpencil_render` tool never returns an ImageBlock — the DeepSeek
  * adapter rejects image blocks anywhere in a request. The browser-only
  * envelope rides `output.presentationMeta` into `ToolCallBlock.meta`, and
  * the keyed `tool.call.toolview` client component renders a PNG-first card
@@ -16,8 +16,11 @@
  */
 import { RENDER_ROUTE_PREFIX, RenderAccessController, prepareRenderAccessKey, } from './renderer.js';
 import { createDesignRenderTool } from './tool.js';
+import { createDesignCreateTool, createDesignEditTool, createDesignSelectionTool, } from './design-tools.js';
 import { VIEWER_ASSET_ROUTE_PREFIX, prepareViewerAssets, } from './viewer-assets.js';
 import { EDITOR_ROUTE_PREFIX, EditorHostController, } from './editor-host.js';
+import { OPENPENCIL_CREATE_TOOL_NAME, OPENPENCIL_EDIT_TOOL_NAME, OPENPENCIL_RENDER_TOOL_NAME, OPENPENCIL_SELECTION_TOOL_NAME, OPENPENCIL_TOOL_NAMES, } from './tool-names.js';
+export { LEGACY_DESIGN_RENDER_TOOL_NAME, OPENPENCIL_CREATE_TOOL_NAME, OPENPENCIL_EDIT_TOOL_NAME, OPENPENCIL_RENDER_TOOL_NAME, OPENPENCIL_SELECTION_TOOL_NAME, OPENPENCIL_TOOL_NAMES, } from './tool-names.js';
 /** Stable plugin name (the loader entry id in cordis.patch.yml). */
 export const name = '@dsh-external/dsh-openpencil';
 /** Services this plugin's root fiber requires. */
@@ -32,14 +35,17 @@ export async function apply(ctx) {
     // Tool registration: global (every agent sees it). The tool's
     // presentationMeta consults `controller.routeAvailable`, so a profile
     // without the webserver still gets a plain-JSON result — no dangling URL.
-    disposers.push(ctx.effect(() => ctx.tools.register(createDesignRenderTool(controller, viewerAssets, editorHost)), 'dsh-openpencil: design_render tool'));
-    // Optional Web routes: only mounted when an httpServer service exists
+    disposers.push(ctx.effect(() => ctx.tools.register(createDesignRenderTool(controller, viewerAssets, editorHost)), `dsh-openpencil: ${OPENPENCIL_RENDER_TOOL_NAME} tool`));
+    disposers.push(ctx.effect(() => ctx.tools.register(createDesignSelectionTool(editorHost)), `dsh-openpencil: ${OPENPENCIL_SELECTION_TOOL_NAME} tool`));
+    disposers.push(ctx.effect(() => ctx.tools.register(createDesignCreateTool(editorHost)), `dsh-openpencil: ${OPENPENCIL_CREATE_TOOL_NAME} tool`));
+    disposers.push(ctx.effect(() => ctx.tools.register(createDesignEditTool(editorHost)), `dsh-openpencil: ${OPENPENCIL_EDIT_TOOL_NAME} tool`));
+    // Optional Web routes: only mounted when a webServer service exists
     // (headless profiles never attach, and `routeAvailable` stays false).
     // The inject fiber is parent-scoped and tears itself down with this ctx;
     // the inner effect's disposer is the route removal.
-    ctx.inject(['httpServer'], (webCtx) => webCtx.effect(() => {
+    ctx.inject(['webServer'], (webCtx) => webCtx.effect(() => {
         const detach = controller.attachRoute();
-        const disposeRoute = webCtx.httpServer.register({
+        const disposeRoute = webCtx.webServer.register({
             kind: 'prefix',
             path: RENDER_ROUTE_PREFIX,
             handler: (req, res) => controller.handle(req, res),
@@ -47,7 +53,7 @@ export async function apply(ctx) {
         const disposeViewerRoute = viewerAssets.available
             ? (() => {
                 const detachViewer = viewerAssets.attachRoute();
-                const disposeViewer = webCtx.httpServer.register({
+                const disposeViewer = webCtx.webServer.register({
                     kind: 'prefix',
                     path: VIEWER_ASSET_ROUTE_PREFIX,
                     handler: (req, res) => viewerAssets.handle(req, res),
@@ -59,7 +65,7 @@ export async function apply(ctx) {
             })()
             : undefined;
         const detachEditor = editorHost.attachRoute();
-        const disposeEditorRoute = webCtx.httpServer.register({
+        const disposeEditorRoute = webCtx.webServer.register({
             kind: 'prefix',
             path: EDITOR_ROUTE_PREFIX,
             handler: (req, res) => editorHost.handle(req, res),
@@ -73,7 +79,7 @@ export async function apply(ctx) {
             detach();
         };
     }, 'dsh-openpencil: render route'));
-    ctx.logger.info(`dsh-openpencil mounted (design_render + gallery + render route; viewer assets: ${viewerAssets.available ? 'ready' : 'unavailable'}; editor: ${editorHost.available ? 'ready' : 'unavailable'})`);
+    ctx.logger.info(`dsh-openpencil mounted (${OPENPENCIL_TOOL_NAMES.join(' + ')}; viewer assets: ${viewerAssets.available ? 'ready' : 'unavailable'}; editor: ${editorHost.available ? 'ready' : 'unavailable'})`);
     return () => {
         for (const dispose of disposers.reverse())
             dispose();

--- a/lib/mcp-client.d.ts
+++ b/lib/mcp-client.d.ts
@@ -1,0 +1,45 @@
+/** Strict loopback JSON-RPC client for one managed OpenPencil editor. */
+export interface OpenPencilNodeSummary {
+    id: string;
+    type?: string;
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+}
+export interface OpenPencilSelectionSnapshot {
+    sourcePath: string;
+    activePageId: string;
+    selectedIds: string[];
+    nodes: OpenPencilNodeSummary[];
+    updatedAt: number;
+}
+export interface OpenPencilMcpResult {
+    tool: string;
+    value: unknown;
+    text: string;
+}
+interface McpCallOptions {
+    baseUrl: string;
+    token: string;
+    tool: string;
+    arguments?: Record<string, unknown>;
+    signal?: AbortSignal;
+    fetcher?: typeof fetch;
+}
+interface McpVersionOptions {
+    baseUrl: string;
+    token: string;
+    signal?: AbortSignal;
+    fetcher?: typeof fetch;
+}
+/** Decode a JSON-RPC tools/call envelope, including MCP's HTTP-200 errors. */
+export declare function parseOpenPencilMcpResponse(tool: string, value: unknown): OpenPencilMcpResult;
+/** Call a first-party tool on a managed editor without exposing its daemon token. */
+export declare function callOpenPencilMcp(options: McpCallOptions): Promise<OpenPencilMcpResult>;
+/** Probe the daemon document version before and after a write. */
+export declare function getOpenPencilMcpVersion(options: McpVersionOptions): Promise<number>;
+/** Project get_selection into the bounded shape shared with the DSH client. */
+export declare function selectionSnapshotFromMcp(sourcePath: string, value: unknown, updatedAt?: number): OpenPencilSelectionSnapshot;
+export {};

--- a/lib/mcp-client.js
+++ b/lib/mcp-client.js
@@ -1,0 +1,146 @@
+/** Strict loopback JSON-RPC client for one managed OpenPencil editor. */
+const MCP_TIMEOUT_MS = 20_000;
+const MAX_MCP_RESPONSE_BYTES = 2 * 1024 * 1024;
+function isRecord(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function finite(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+function optionalString(value) {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+function textFromContent(value) {
+    if (!Array.isArray(value))
+        return '';
+    const parts = [];
+    for (const item of value) {
+        if (isRecord(item) && item.type === 'text' && typeof item.text === 'string')
+            parts.push(item.text);
+    }
+    return parts.join('\n');
+}
+/** Decode a JSON-RPC tools/call envelope, including MCP's HTTP-200 errors. */
+export function parseOpenPencilMcpResponse(tool, value) {
+    if (!isRecord(value))
+        throw new Error(`OpenPencil MCP ${tool} returned an invalid JSON-RPC response`);
+    if (isRecord(value.error)) {
+        const message = optionalString(value.error.message) ?? JSON.stringify(value.error);
+        throw new Error(`OpenPencil MCP ${tool} failed: ${message}`);
+    }
+    if (!isRecord(value.result))
+        throw new Error(`OpenPencil MCP ${tool} omitted its result`);
+    const text = textFromContent(value.result.content);
+    if (value.result.isError === true) {
+        throw new Error(`OpenPencil MCP ${tool} failed${text === '' ? '' : `: ${text}`}`);
+    }
+    let decoded = text;
+    if (text !== '') {
+        try {
+            decoded = JSON.parse(text);
+        }
+        catch {
+            // Some first-party tools intentionally return human-readable text.
+        }
+    }
+    if (isRecord(decoded) && decoded.applied === false) {
+        const details = Array.isArray(decoded.errors)
+            ? decoded.errors.map(error => typeof error === 'string' ? error : JSON.stringify(error)).join('; ')
+            : text;
+        throw new Error(`OpenPencil MCP ${tool} did not apply${details === '' ? '' : `: ${details}`}`);
+    }
+    return { tool, value: decoded, text };
+}
+/** Call a first-party tool on a managed editor without exposing its daemon token. */
+export async function callOpenPencilMcp(options) {
+    const origin = new URL(options.baseUrl);
+    const loopback = origin.hostname === '127.0.0.1' || origin.hostname === 'localhost' || origin.hostname === '::1';
+    if (!loopback || (origin.protocol !== 'http:' && origin.protocol !== 'https:')) {
+        throw new Error('OpenPencil MCP endpoint must use an HTTP loopback origin');
+    }
+    if (origin.pathname !== '/' || origin.search !== '' || origin.hash !== '') {
+        throw new Error('OpenPencil MCP base URL must be an origin');
+    }
+    const fetcher = options.fetcher ?? fetch;
+    const timeout = AbortSignal.timeout(MCP_TIMEOUT_MS);
+    const signal = options.signal === undefined ? timeout : AbortSignal.any([options.signal, timeout]);
+    const response = await fetcher(new URL('/mcp', origin).href, {
+        method: 'POST',
+        headers: {
+            authorization: `Bearer ${options.token}`,
+            'x-openpencil-token': options.token,
+            'content-type': 'application/json',
+            accept: 'application/json',
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: `dsh-${Date.now().toString(36)}`,
+            method: 'tools/call',
+            params: { name: options.tool, arguments: options.arguments ?? {} },
+        }),
+        signal,
+    });
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.length > MAX_MCP_RESPONSE_BYTES)
+        throw new Error(`OpenPencil MCP ${options.tool} response is too large`);
+    if (!response.ok)
+        throw new Error(`OpenPencil MCP ${options.tool} request failed (${response.status})`);
+    let value;
+    try {
+        value = JSON.parse(bytes.toString('utf8'));
+    }
+    catch {
+        throw new Error(`OpenPencil MCP ${options.tool} returned invalid JSON`);
+    }
+    return parseOpenPencilMcpResponse(options.tool, value);
+}
+/** Probe the daemon document version before and after a write. */
+export async function getOpenPencilMcpVersion(options) {
+    const origin = new URL(options.baseUrl);
+    const loopback = origin.hostname === '127.0.0.1' || origin.hostname === 'localhost' || origin.hostname === '::1';
+    if (!loopback || (origin.protocol !== 'http:' && origin.protocol !== 'https:')) {
+        throw new Error('OpenPencil MCP endpoint must use an HTTP loopback origin');
+    }
+    const response = await (options.fetcher ?? fetch)(new URL('/api/mcp/version', origin).href, {
+        headers: { authorization: `Bearer ${options.token}`, 'x-openpencil-token': options.token },
+        signal: options.signal,
+    });
+    if (!response.ok)
+        throw new Error(`OpenPencil MCP version probe failed (${response.status})`);
+    const value = await response.json();
+    if (!isRecord(value) || typeof value.version !== 'number' || !Number.isSafeInteger(value.version) || value.version < 0) {
+        throw new Error('OpenPencil MCP version probe returned an invalid result');
+    }
+    return value.version;
+}
+function nodeSummary(value) {
+    if (!isRecord(value) || typeof value.id !== 'string' || value.id.length === 0)
+        return undefined;
+    return {
+        id: value.id,
+        ...(optionalString(value.type) === undefined ? {} : { type: optionalString(value.type) }),
+        ...(optionalString(value.name) === undefined ? {} : { name: optionalString(value.name) }),
+        ...(finite(value.x) === undefined ? {} : { x: finite(value.x) }),
+        ...(finite(value.y) === undefined ? {} : { y: finite(value.y) }),
+        ...(finite(value.width) === undefined ? {} : { width: finite(value.width) }),
+        ...(finite(value.height) === undefined ? {} : { height: finite(value.height) }),
+    };
+}
+/** Project get_selection into the bounded shape shared with the DSH client. */
+export function selectionSnapshotFromMcp(sourcePath, value, updatedAt = Date.now()) {
+    if (!isRecord(value))
+        throw new Error('OpenPencil get_selection returned an invalid result');
+    const selectedIds = Array.isArray(value.selectedIds)
+        ? value.selectedIds.filter((id) => typeof id === 'string' && id.length > 0)
+        : [];
+    const nodes = Array.isArray(value.nodes)
+        ? value.nodes.map(nodeSummary).filter((node) => node !== undefined)
+        : [];
+    return {
+        sourcePath,
+        activePageId: optionalString(value.activePageId) ?? '',
+        selectedIds,
+        nodes,
+        updatedAt,
+    };
+}

--- a/lib/renderer.d.ts
+++ b/lib/renderer.d.ts
@@ -1,7 +1,7 @@
 /**
  * Offscreen rendering + signed HTTP delivery for `.op` documents.
  *
- * `design_render` snapshots the source document, uses OpenPencil's own
+ * `openpencil_render` snapshots the source document, uses OpenPencil's own
  * headless exporter for design-fidelity PNG output, retaining every
  * top-level frame for the conversation gallery, and only invokes Jian
  * as an explicitly disclosed runtime-preview fallback when the exact binary
@@ -17,6 +17,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { JsonValue } from '@deepseek-ai/dsh-tools';
 import type { ViewerGrant } from './viewer-assets.js';
 import type { EditorGrant } from './editor-host.js';
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js';
 /** HTTP prefix owned by the render capability route. */
 export declare const RENDER_ROUTE_PREFIX = "/_dsh/dsh-openpencil/render";
 /** Presentation metadata key reserved by the browser half of this package. */
@@ -84,7 +85,7 @@ export interface RenderResult {
     mimeType: 'image/png';
     kind: 'image';
     description: string;
-    sourceTool: 'design_render';
+    sourceTool: typeof OPENPENCIL_RENDER_TOOL_NAME;
     previewIntent: 'image';
     bytes: number;
     width?: number;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,7 +1,7 @@
 /**
  * Offscreen rendering + signed HTTP delivery for `.op` documents.
  *
- * `design_render` snapshots the source document, uses OpenPencil's own
+ * `openpencil_render` snapshots the source document, uses OpenPencil's own
  * headless exporter for design-fidelity PNG output, retaining every
  * top-level frame for the conversation gallery, and only invokes Jian
  * as an explicitly disclosed runtime-preview fallback when the exact binary
@@ -20,6 +20,7 @@ import { spawn } from 'node:child_process';
 import { homedir } from 'node:os';
 import { basename, delimiter, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js';
 /** HTTP prefix owned by the render capability route. */
 export const RENDER_ROUTE_PREFIX = '/_dsh/dsh-openpencil/render';
 /** Presentation metadata key reserved by the browser half of this package. */
@@ -372,7 +373,7 @@ export function expandUserHome(raw) {
  */
 export async function resolveInputFile(raw, cwd) {
     if (typeof raw !== 'string' || raw.trim().length === 0) {
-        throw new Error('design_render: path is required');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: path is required`);
     }
     const expanded = expandUserHome(raw.trim());
     const target = isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
@@ -381,14 +382,14 @@ export async function resolveInputFile(raw, cwd) {
         real = await realpath(target);
     }
     catch {
-        throw new Error(`design_render: .op file not found: ${raw}`);
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: .op file not found: ${raw}`);
     }
     const info = await stat(real);
     if (!info.isFile())
-        throw new Error(`design_render: not a regular file: ${raw}`);
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: not a regular file: ${raw}`);
     const extension = real.slice(real.lastIndexOf('.')).toLowerCase();
     if (extension !== '.op') {
-        throw new Error(`design_render: expected a .op file (got "${extension || '(none)'}")`);
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: expected a .op file (got "${extension || '(none)'}")`);
     }
     return real;
 }
@@ -396,9 +397,9 @@ export async function resolveInputFile(raw, cwd) {
 export async function createDocumentSnapshot(input) {
     const bytes = await readFile(input);
     if (bytes.length === 0)
-        throw new Error('design_render: source document is empty');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: source document is empty`);
     if (bytes.length > MAX_DOCUMENT_BYTES) {
-        throw new Error(`design_render: source document exceeds ${MAX_DOCUMENT_BYTES} bytes`);
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: source document exceeds ${MAX_DOCUMENT_BYTES} bytes`);
     }
     const sha256 = createHash('sha256').update(bytes).digest('hex');
     const filename = `${sha256}.op`;
@@ -412,7 +413,7 @@ export async function createDocumentSnapshot(input) {
             throw error;
         const existing = await readFile(path);
         if (existing.length !== bytes.length || createHash('sha256').update(existing).digest('hex') !== sha256) {
-            throw new Error('design_render: content-addressed snapshot was modified');
+            throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: content-addressed snapshot was modified`);
         }
     }
     return { path, filename, mimeType: 'application/json', bytes: bytes.length, sha256 };
@@ -571,7 +572,7 @@ async function sourceFrameDescriptors(path) {
 export async function runOpenPencilRender(options) {
     const scale = options.scale ?? 1;
     if (!Number.isFinite(scale) || scale <= 0 || scale > 8) {
-        throw new Error('design_render: scale must be a finite number greater than 0 and at most 8');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: scale must be a finite number greater than 0 and at most 8`);
     }
     await mkdir(stateRoot(), { recursive: true, mode: 0o700 });
     const tempRoot = await mkdtemp(join(stateRoot(), 'exact-'));
@@ -607,9 +608,9 @@ export async function runOpenPencilRender(options) {
         const stdout = Buffer.concat(stdoutChunks).toString('utf8');
         const stderr = Buffer.concat(stderrChunks).toString('utf8');
         if (options.signal.aborted)
-            throw new Error('design_render: OpenPencil render was cancelled');
+            throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: OpenPencil render was cancelled`);
         if (timedOut)
-            throw new Error(`design_render: OpenPencil render timed out after ${RENDER_TIMEOUT_MS} ms`);
+            throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: OpenPencil render timed out after ${RENDER_TIMEOUT_MS} ms`);
         if (code !== 0)
             throw new Error(`OpenPencil render exited with ${String(code)}${stderr.trim() === '' ? '' : `: ${stderr.trim()}`}`);
         const discoveredPngs = (await readdir(outDir)).filter(name => name.toLowerCase().endsWith('.png'));
@@ -634,7 +635,7 @@ export async function runOpenPencilRender(options) {
                     .sort(),
             ])];
         if (pngs.length === 0)
-            throw new Error('design_render: OpenPencil produced no PNG');
+            throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: OpenPencil produced no PNG`);
         const sourceFrameByPng = new Map(sourceFrames.map(frame => [rendererFilename(frame.id), frame]));
         const frames = [];
         try {
@@ -742,25 +743,25 @@ export async function createRenderOutput() {
 export async function verifyRenderOutput(out) {
     const info = await lstat(out);
     if (info.isSymbolicLink() || !info.isFile())
-        throw new Error('design_render: renderer did not produce a regular file');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: renderer did not produce a regular file`);
     if (info.size > MAX_RENDER_BYTES)
-        throw new Error(`design_render: rendered PNG exceeds ${MAX_RENDER_BYTES} bytes`);
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG exceeds ${MAX_RENDER_BYTES} bytes`);
     if (info.size < 33)
-        throw new Error('design_render: rendered PNG is truncated');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG is truncated`);
     const bytes = await readFile(out);
     const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     if (!bytes.subarray(0, 8).equals(signature))
-        throw new Error('design_render: renderer output is not a PNG');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: renderer output is not a PNG`);
     if (bytes.readUInt32BE(8) !== 13 || bytes.toString('ascii', 12, 16) !== 'IHDR') {
-        throw new Error('design_render: PNG has no valid IHDR');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: PNG has no valid IHDR`);
     }
     const width = bytes.readUInt32BE(16);
     const height = bytes.readUInt32BE(20);
     if (width === 0 || height === 0 || width > MAX_RENDER_DIMENSION || height > MAX_RENDER_DIMENSION) {
-        throw new Error('design_render: rendered PNG dimensions are invalid');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG dimensions are invalid`);
     }
     if (width * height > MAX_RENDER_PIXELS)
-        throw new Error('design_render: rendered PNG has too many pixels');
+        throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG has too many pixels`);
     return {
         bytes: info.size,
         width,

--- a/lib/tool-names.d.ts
+++ b/lib/tool-names.d.ts
@@ -1,0 +1,12 @@
+/** Canonical model-facing OpenPencil tool names. */
+export declare const OPENPENCIL_RENDER_TOOL_NAME: "openpencil_render";
+export declare const OPENPENCIL_SELECTION_TOOL_NAME: "openpencil_selection";
+export declare const OPENPENCIL_CREATE_TOOL_NAME: "openpencil_create";
+export declare const OPENPENCIL_EDIT_TOOL_NAME: "openpencil_edit";
+/**
+ * Historical render name retained only by the browser presentation layer so
+ * existing conversation cards and details panels remain replayable. The host
+ * deliberately does not register this alias as a model-facing tool.
+ */
+export declare const LEGACY_DESIGN_RENDER_TOOL_NAME: "design_render";
+export declare const OPENPENCIL_TOOL_NAMES: readonly ["openpencil_render", "openpencil_selection", "openpencil_create", "openpencil_edit"];

--- a/lib/tool-names.js
+++ b/lib/tool-names.js
@@ -1,0 +1,17 @@
+/** Canonical model-facing OpenPencil tool names. */
+export const OPENPENCIL_RENDER_TOOL_NAME = 'openpencil_render';
+export const OPENPENCIL_SELECTION_TOOL_NAME = 'openpencil_selection';
+export const OPENPENCIL_CREATE_TOOL_NAME = 'openpencil_create';
+export const OPENPENCIL_EDIT_TOOL_NAME = 'openpencil_edit';
+/**
+ * Historical render name retained only by the browser presentation layer so
+ * existing conversation cards and details panels remain replayable. The host
+ * deliberately does not register this alias as a model-facing tool.
+ */
+export const LEGACY_DESIGN_RENDER_TOOL_NAME = 'design_render';
+export const OPENPENCIL_TOOL_NAMES = [
+    OPENPENCIL_RENDER_TOOL_NAME,
+    OPENPENCIL_SELECTION_TOOL_NAME,
+    OPENPENCIL_CREATE_TOOL_NAME,
+    OPENPENCIL_EDIT_TOOL_NAME,
+];

--- a/lib/tool.d.ts
+++ b/lib/tool.d.ts
@@ -1,5 +1,5 @@
 /**
- * `design_render` — render a `.op` design document to PNG without a
+ * `openpencil_render` — render a `.op` design document to PNG without a
  * window. OpenPencil's own exporter is the exact primary path; Jian is an
  * explicitly-labelled runtime-preview fallback when that binary is absent.
  *
@@ -21,5 +21,5 @@ export interface DesignRenderArgs {
     /** Explicitly expose the original source to the managed sidebar editor. */
     editable?: boolean;
 }
-/** Create the `design_render` tool definition bound to one controller. */
+/** Create the `openpencil_render` tool definition bound to one controller. */
 export declare function createDesignRenderTool(controller: RenderAccessController, viewerAssets?: ViewerAssetController, editorHost?: EditorHostController): import("@deepseek-ai/dsh-tools").ToolDefinition;

--- a/lib/tool.js
+++ b/lib/tool.js
@@ -1,5 +1,5 @@
 /**
- * `design_render` — render a `.op` design document to PNG without a
+ * `openpencil_render` — render a `.op` design document to PNG without a
  * window. OpenPencil's own exporter is the exact primary path; Jian is an
  * explicitly-labelled runtime-preview fallback when that binary is absent.
  *
@@ -13,6 +13,7 @@
 import { defineTool } from '@deepseek-ai/dsh-tools';
 import { basename } from 'node:path';
 import { RendererBinaryMissingError, createDocumentSnapshot, createRenderOutput, findOpenPencilBinary, findJianBinary, projectRenderGrant, resolveInputFile, runOpenPencilRender, runJianRender, verifyRenderOutput, } from './renderer.js';
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js';
 /** Session workspace the caller resolves paths against (mirrors first-party tools). */
 function sessionWorkspace(exec) {
     return exec.agent?.session.header.cwd ?? process.cwd();
@@ -31,10 +32,10 @@ function makePresentationMeta(controller, viewerAssets, editorHost) {
         return projectRenderGrant(value, controller, viewerAssets?.viewerGrant, editor);
     };
 }
-/** Create the `design_render` tool definition bound to one controller. */
+/** Create the `openpencil_render` tool definition bound to one controller. */
 export function createDesignRenderTool(controller, viewerAssets, editorHost) {
     return defineTool({
-        name: 'design_render',
+        name: OPENPENCIL_RENDER_TOOL_NAME,
         description: 'Render an OpenPencil .op design document exactly as the design canvas, '
             + 'then show a PNG and an optional interactive read-only canvas in the conversation. '
             + 'Give the absolute path to a .op file (or a path relative to the session workspace). '
@@ -59,7 +60,7 @@ export function createDesignRenderTool(controller, viewerAssets, editorHost) {
                     mimeType: { type: 'string', const: 'image/png', required: true },
                     kind: { type: 'string', const: 'image', required: true },
                     description: { type: 'string', required: true },
-                    sourceTool: { type: 'string', const: 'design_render', required: true },
+                    sourceTool: { type: 'string', const: OPENPENCIL_RENDER_TOOL_NAME, required: true },
                     previewIntent: { type: 'string', const: 'image', required: true },
                     bytes: { type: 'integer', required: true },
                     width: { type: 'integer' },
@@ -120,7 +121,7 @@ export function createDesignRenderTool(controller, viewerAssets, editorHost) {
             const openPencil = findOpenPencilBinary();
             if (openPencil !== undefined) {
                 if (args.width !== undefined || args.height !== undefined) {
-                    throw new Error('design_render: width/height are not supported by the exact OpenPencil renderer; omit them and use scale');
+                    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: width/height are not supported by the exact OpenPencil renderer; omit them and use scale`);
                 }
                 try {
                     const exact = await runOpenPencilRender({
@@ -189,7 +190,7 @@ export function createDesignRenderTool(controller, viewerAssets, editorHost) {
                 mimeType: 'image/png',
                 kind: 'image',
                 description: `Rendered ${input} with ${renderer} (${fidelity})`,
-                sourceTool: 'design_render',
+                sourceTool: OPENPENCIL_RENDER_TOOL_NAME,
                 previewIntent: 'image',
                 bytes: verified.bytes,
                 width: verified.width,

--- a/lib/types/client/details-compat.d.ts
+++ b/lib/types/client/details-compat.d.ts
@@ -1,0 +1,28 @@
+/** Compatibility boundary for DSH builds before the keyed Tool details seam. */
+import type { ToolCallViewProps } from '@deepseek-ai/dsh-client-ui-tool/client';
+import type { DetailsToolOwnerProps } from '@deepseek-ai/dsh-client-ui-conversation/client';
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots';
+/**
+ * rc.2 does not declare this slot. Declaring the same contract locally keeps
+ * the plugin type-safe on rc.2 and is identical to the declaration shipped by
+ * newer DSH builds. At runtime `slots.inject()` waits while a slot is absent,
+ * so no registration is attempted until a supporting DSH host declares it.
+ */
+declare module '@deepseek-ai/dsh-client-ui-slots' {
+    interface SlotMap {
+        'tool.details.toolview': {
+            kind: 'keyed';
+            scope: 'session';
+            owner: DetailsToolOwnerProps;
+        };
+    }
+}
+/** Details props without importing a symbol absent from stock rc.2. */
+export type CompatibleToolDetailsViewProps = PropsRuntime<'tool.details.toolview'>;
+/** Call props with the additive newer-DSH sidebar capability. */
+export type CompatibleToolCallViewProps = ToolCallViewProps & {
+    openDetails?: (() => void) | undefined;
+};
+export type OpenPencilEditorSurface = 'details' | 'modal';
+/** Prefer the native resident details panel and otherwise open our own modal. */
+export declare function requestOpenPencilEditor(openDetails: (() => void) | undefined, openModal: () => void): OpenPencilEditorSurface;

--- a/lib/types/client/editor-modal.d.ts
+++ b/lib/types/client/editor-modal.d.ts
@@ -1,0 +1,19 @@
+/** Managed OpenPencil editor fallback for DSH builds without Tool details. */
+import type { PresentationGrant } from './index.js';
+import { type EditorColorScheme, type EditorLocale } from './editor-bridge.js';
+interface EditorModalCopy {
+    title: string;
+    close: string;
+    discard: string;
+}
+export declare function editorModalCopy(locale: EditorLocale): EditorModalCopy;
+/** Read the editor's durable dirty marker before allowing the modal to close. */
+export declare function confirmEditorModalClose(root: Pick<ParentNode, 'querySelector'> | null, message: string, confirm?: ((message?: string) => boolean) & typeof globalThis.confirm): boolean;
+export declare function ManagedOpenPencilEditorModal({ grant, colorScheme, locale, sessionId, onClose, }: {
+    grant: PresentationGrant;
+    colorScheme: EditorColorScheme;
+    locale: EditorLocale;
+    sessionId: string;
+    onClose: () => void;
+}): import("react").JSX.Element;
+export {};

--- a/lib/types/client/editor-panel.d.ts
+++ b/lib/types/client/editor-panel.d.ts
@@ -6,6 +6,7 @@ export interface LaunchResponse {
     iframeUrl: string;
     token: string;
     saveUrl: string;
+    selectionUrl?: string;
     closeUrl: string;
     docJson?: string;
     /** Client-only marker: the persisted launch capability was renewed. */
@@ -34,6 +35,12 @@ export declare function editorPanelCopy(locale: EditorLocale): EditorPanelCopy;
 interface EditorBootOptions {
     signal?: AbortSignal;
     fetcher?: typeof fetch;
+    sessionId?: string;
+}
+interface EditorCloseOptions {
+    fetcher?: typeof fetch;
+    dirty?: boolean;
+    keepalive?: boolean;
 }
 /**
  * Launch one editor, renewing exactly once when a replayed launch capability
@@ -43,10 +50,18 @@ interface EditorBootOptions {
 export declare function launchManagedEditor(editor: NonNullable<PresentationGrant['editor']>, document: NonNullable<PresentationGrant['document']>, options?: EditorBootOptions): Promise<LaunchResponse>;
 /** Prefer the daemon's current source; fetch the immutable snapshot only for old hosts. */
 export declare function prepareManagedEditor(editor: NonNullable<PresentationGrant['editor']>, document: NonNullable<PresentationGrant['document']>, options?: EditorBootOptions): Promise<EditorBootResult>;
+/** Close exactly the managed session returned by one launch response. */
+export declare function closeManagedEditorLaunch(launch: LaunchResponse, options?: EditorCloseOptions): Promise<void>;
+/**
+ * Mount-aware boot boundary. React may cancel an effect after its launch POST
+ * has committed; release that precise returned session before ignoring it.
+ */
+export declare function prepareManagedEditorForMount(editor: NonNullable<PresentationGrant['editor']>, document: NonNullable<PresentationGrant['document']>, accept: () => boolean, options?: EditorBootOptions): Promise<EditorBootResult | undefined>;
 /** Editable panel. The daemon is created lazily only while this component is mounted. */
-export declare function ManagedOpenPencilEditor({ grant, colorScheme, locale }: {
+export declare function ManagedOpenPencilEditor({ grant, colorScheme, locale, sessionId }: {
     grant: PresentationGrant;
     colorScheme: EditorColorScheme;
     locale: EditorLocale;
+    sessionId: string;
 }): import("react").JSX.Element;
 export {};

--- a/lib/types/client/frame-gallery.d.ts
+++ b/lib/types/client/frame-gallery.d.ts
@@ -85,6 +85,8 @@ export declare const GALLERY_COMPACT_MAX_HEIGHT = 560;
 /** Shared geometry keeps labels and glyphs on one visual center line. */
 export declare const GALLERY_TOOLBAR_CONTROL_HEIGHT = 28;
 export declare const GALLERY_TOOLBAR_CONTROL_LAYOUT: Readonly<React.CSSProperties>;
+/** Optical correction for CJK labels and +/- glyphs inside the centered control box. */
+export declare const GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT: Readonly<React.CSSProperties>;
 export declare function galleryViewportMaxHeight(fitContent: boolean): number | undefined;
 export interface FrameGalleryProps {
     frames: readonly GalleryFrame[];

--- a/lib/types/client/index.d.ts
+++ b/lib/types/client/index.d.ts
@@ -1,5 +1,6 @@
 /**
- * Browser presentation for `design_render`.
+ * Browser presentation for `openpencil_render` and historical
+ * `design_render` conversation cards.
  *
  * PNG remains the replay-safe default. When the host also grants access to
  * the source `.op`, the user can opt into one shared, read-only Web SDK
@@ -9,15 +10,19 @@ import type { ToolCallViewProps, ToolDetailsViewProps } from '@deepseek-ai/dsh-c
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client';
 import { type EditorColorScheme, type EditorLocale } from './editor-bridge.js';
 import type { GalleryFrame, GalleryLocale } from './frame-gallery.js';
-export { calculateGalleryFitViewZoom, clampGalleryZoom, frameLabel, frameGalleryCopy, galleryZoomCommandTarget, galleryViewportMaxHeight, galleryZoomPercent, galleryZoomShortcut, GALLERY_COMPACT_MAX_HEIGHT, GALLERY_TOOLBAR_CONTROL_HEIGHT, GALLERY_TOOLBAR_CONTROL_LAYOUT, GALLERY_ZOOM_MAX, GALLERY_ZOOM_MIN, GALLERY_ZOOM_STEP, nextGalleryZoom, normalizeFrameIndex, } from './frame-gallery.js';
-export { editorPanelCopy, launchManagedEditor, prepareManagedEditor } from './editor-panel.js';
+export { LEGACY_DESIGN_RENDER_TOOL_NAME, OPENPENCIL_RENDER_TOOL_NAME, } from '../tool-names.js';
+export { calculateGalleryFitViewZoom, clampGalleryZoom, frameLabel, frameGalleryCopy, galleryZoomCommandTarget, galleryViewportMaxHeight, galleryZoomPercent, galleryZoomShortcut, GALLERY_COMPACT_MAX_HEIGHT, GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT, GALLERY_TOOLBAR_CONTROL_HEIGHT, GALLERY_TOOLBAR_CONTROL_LAYOUT, GALLERY_ZOOM_MAX, GALLERY_ZOOM_MIN, GALLERY_ZOOM_STEP, nextGalleryZoom, normalizeFrameIndex, } from './frame-gallery.js';
+export { closeManagedEditorLaunch, editorPanelCopy, launchManagedEditor, prepareManagedEditor, prepareManagedEditorForMount, } from './editor-panel.js';
 export { editorGrantForBoot, editorSuccessorFromSave, editorSuccessorStorageKey, rememberEditorSuccessor, } from './editor-successor.js';
 export { claimEditor, confirmEditorClose, editorControlUrl, editorIframeUrlWithLocale, editorIframeUrlWithTheme, editorLocaleFromDsh, editorMessageFrom, editorOrigin, encodeEditorOutbound, parseEditorInbound, } from './editor-bridge.js';
+export { clearOpenPencilSelection, getOpenPencilSelectionSnapshot, liveSelectionOf, publishOpenPencilSelection, subscribeOpenPencilSelection, } from './selection-store.js';
+export { isTerminalEditorSelectionStatus, startEditorSelectionPolling, } from './selection-polling.js';
+export { hasOpenPencilSelection, OPENPENCIL_SELECTION_DOCK_LAYOUT, selectionNodeDetail, selectionNodeLabel, } from './selection-dock.js';
 /** Presentation metadata key the host half projects into `block.meta`. */
 export declare const PRESENTATION_META_KEY = "$dshOpenPencil";
 export type PresentationLocale = GalleryLocale;
 export declare function designRenderCopy(locale: PresentationLocale): {
-    readonly designRender: "Design render";
+    readonly designRender: "OpenPencil render";
     readonly error: "error";
     readonly rendering: "rendering…";
     readonly done: "done";
@@ -46,7 +51,7 @@ export declare function designRenderCopy(locale: PresentationLocale): {
     readonly snapshot: "snapshot";
     readonly editorUnavailable: "Editable OpenPencil canvas is not available for this result.";
 } | {
-    readonly designRender: "设计渲染";
+    readonly designRender: "OpenPencil 渲染";
     readonly error: "错误";
     readonly rendering: "渲染中…";
     readonly done: "完成";
@@ -140,16 +145,16 @@ export declare function sizeCanvasForDisplay(canvas: Pick<HTMLCanvasElement, 'cl
     cssHeight: number;
     dpr: number;
 };
-/** Render one `design_render` tool call as a PNG-first card. */
+/** Render one OpenPencil render tool call as a PNG-first card. */
 export declare function DesignRenderView({ block, openDetails, openFile, inspect, locale }: ToolCallViewProps & {
     locale?: PresentationLocale;
 }): import("react").JSX.Element;
 /** Render the selected editable design inside DSH's resident details column. */
-export declare function OpenPencilEditorPanel({ block, colorScheme, locale }: ToolDetailsViewProps & {
+export declare function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }: ToolDetailsViewProps & {
     colorScheme: EditorColorScheme;
     locale: EditorLocale;
 }): import("react").JSX.Element;
 /** Required client services. */
 export declare const inject: string[];
-/** Register the dedicated toolview for `design_render`. */
+/** Register canonical views plus a presentation-only alias for replaying historical cards. */
 export declare function apply(ctx: ClientContext): void;

--- a/lib/types/client/index.d.ts
+++ b/lib/types/client/index.d.ts
@@ -6,13 +6,16 @@
  * the source `.op`, the user can opt into one shared, read-only Web SDK
  * canvas. The SDK and document are fetched only after that explicit action.
  */
-import type { ToolCallViewProps, ToolDetailsViewProps } from '@deepseek-ai/dsh-client-ui-tool/client';
+import type { ToolCallViewProps } from '@deepseek-ai/dsh-client-ui-tool/client';
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client';
 import { type EditorColorScheme, type EditorLocale } from './editor-bridge.js';
+import { type CompatibleToolCallViewProps, type CompatibleToolDetailsViewProps } from './details-compat.js';
 import type { GalleryFrame, GalleryLocale } from './frame-gallery.js';
 export { LEGACY_DESIGN_RENDER_TOOL_NAME, OPENPENCIL_RENDER_TOOL_NAME, } from '../tool-names.js';
 export { calculateGalleryFitViewZoom, clampGalleryZoom, frameLabel, frameGalleryCopy, galleryZoomCommandTarget, galleryViewportMaxHeight, galleryZoomPercent, galleryZoomShortcut, GALLERY_COMPACT_MAX_HEIGHT, GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT, GALLERY_TOOLBAR_CONTROL_HEIGHT, GALLERY_TOOLBAR_CONTROL_LAYOUT, GALLERY_ZOOM_MAX, GALLERY_ZOOM_MIN, GALLERY_ZOOM_STEP, nextGalleryZoom, normalizeFrameIndex, } from './frame-gallery.js';
 export { closeManagedEditorLaunch, editorPanelCopy, launchManagedEditor, prepareManagedEditor, prepareManagedEditorForMount, } from './editor-panel.js';
+export { requestOpenPencilEditor, } from './details-compat.js';
+export { confirmEditorModalClose, editorModalCopy, } from './editor-modal.js';
 export { editorGrantForBoot, editorSuccessorFromSave, editorSuccessorStorageKey, rememberEditorSuccessor, } from './editor-successor.js';
 export { claimEditor, confirmEditorClose, editorControlUrl, editorIframeUrlWithLocale, editorIframeUrlWithTheme, editorLocaleFromDsh, editorMessageFrom, editorOrigin, encodeEditorOutbound, parseEditorInbound, } from './editor-bridge.js';
 export { clearOpenPencilSelection, getOpenPencilSelectionSnapshot, liveSelectionOf, publishOpenPencilSelection, subscribeOpenPencilSelection, } from './selection-store.js';
@@ -30,6 +33,7 @@ export declare function designRenderCopy(locale: PresentationLocale): {
     readonly renderFailed: "The render failed.";
     readonly frames: "frames";
     readonly openInteractiveCanvas: "Open interactive canvas";
+    readonly editCanvas: "Edit canvas";
     readonly editInSidebar: "Edit in sidebar";
     readonly openRenderedPng: "Open rendered PNG";
     readonly downloadPng: "Download PNG";
@@ -59,6 +63,7 @@ export declare function designRenderCopy(locale: PresentationLocale): {
     readonly renderFailed: "渲染失败。";
     readonly frames: "页";
     readonly openInteractiveCanvas: "打开交互画布";
+    readonly editCanvas: "编辑画布";
     readonly editInSidebar: "在侧边栏编辑";
     readonly openRenderedPng: "打开渲染 PNG";
     readonly downloadPng: "下载 PNG";
@@ -146,11 +151,13 @@ export declare function sizeCanvasForDisplay(canvas: Pick<HTMLCanvasElement, 'cl
     dpr: number;
 };
 /** Render one OpenPencil render tool call as a PNG-first card. */
-export declare function DesignRenderView({ block, openDetails, openFile, inspect, locale }: ToolCallViewProps & {
+export declare function DesignRenderView({ block, openDetails, openFile, inspect, locale, colorScheme, editorLocale, sessionId, }: CompatibleToolCallViewProps & {
     locale?: PresentationLocale;
+    colorScheme?: EditorColorScheme;
+    editorLocale?: EditorLocale;
 }): import("react").JSX.Element;
 /** Render the selected editable design inside DSH's resident details column. */
-export declare function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }: ToolDetailsViewProps & {
+export declare function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }: CompatibleToolDetailsViewProps & {
     colorScheme: EditorColorScheme;
     locale: EditorLocale;
 }): import("react").JSX.Element;

--- a/lib/types/client/selection-dock.d.ts
+++ b/lib/types/client/selection-dock.d.ts
@@ -1,0 +1,18 @@
+/** Live OpenPencil selection chip rendered above the DSH composer. */
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots';
+import { type OpenPencilLiveSelection } from './selection-store.js';
+import type { PresentationLocale } from './index.js';
+export declare const OPENPENCIL_SELECTION_DOCK_LAYOUT: {
+    readonly boxSizing: "border-box";
+    readonly flex: "none";
+    readonly width: "calc(100% - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))";
+    readonly maxWidth: "calc(var(--dsh-composer-card-max-width, 780px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))";
+    readonly margin: "0 auto";
+};
+export declare function hasOpenPencilSelection(selection: OpenPencilLiveSelection | undefined): selection is OpenPencilLiveSelection;
+export declare function selectionNodeLabel(selection: OpenPencilLiveSelection, locale: PresentationLocale): string;
+export declare function selectionNodeDetail(selection: OpenPencilLiveSelection, locale: PresentationLocale): string;
+export type OpenPencilSelectionDockProps = PropsRuntime<'conversation.input.dock'> & {
+    locale: PresentationLocale;
+};
+export declare function OpenPencilSelectionDock({ sessionId, locale }: OpenPencilSelectionDockProps): import("react").JSX.Element | null;

--- a/lib/types/client/selection-polling.d.ts
+++ b/lib/types/client/selection-polling.d.ts
@@ -1,0 +1,24 @@
+/** Lifecycle-safe polling for the optional OpenPencil live-selection endpoint. */
+export interface SelectionPollTimer {
+    schedule(callback: () => void, delayMs: number): unknown;
+    cancel(handle: unknown): void;
+}
+export interface EditorSelectionPollingOptions {
+    url: string;
+    onValue(value: unknown): void;
+    onStop(): void;
+    fetcher?: typeof fetch;
+    intervalMs?: number;
+    timer?: SelectionPollTimer;
+}
+/** Client failures other than retry-oriented HTTP statuses cannot recover by polling. */
+export declare function isTerminalEditorSelectionStatus(status: number): boolean;
+/**
+ * Start one immediate poll followed by non-overlapping delayed polls.
+ *
+ * The returned cleanup is idempotent, aborts an in-flight request, cancels the
+ * pending timer, and invokes `onStop` exactly once. Terminal HTTP responses
+ * use the same cleanup path; network errors and retryable statuses schedule a
+ * later attempt without disrupting the editor itself.
+ */
+export declare function startEditorSelectionPolling(options: EditorSelectionPollingOptions): () => void;

--- a/lib/types/client/selection-store.d.ts
+++ b/lib/types/client/selection-store.d.ts
@@ -1,0 +1,26 @@
+/** Page-local live selection store shared by the sidebar and conversation. */
+export interface OpenPencilNodeSelection {
+    id: string;
+    type?: string;
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+}
+export interface OpenPencilLiveSelection {
+    sourcePath: string;
+    activePageId: string;
+    selectedIds: string[];
+    nodes: OpenPencilNodeSelection[];
+    updatedAt: number;
+}
+export interface OpenPencilSelectionStoreSnapshot {
+    revision: number;
+    selection?: OpenPencilLiveSelection;
+}
+export declare function liveSelectionOf(value: unknown): OpenPencilLiveSelection | undefined;
+export declare function publishOpenPencilSelection(sessionId: string, selection: OpenPencilLiveSelection): void;
+export declare function clearOpenPencilSelection(sessionId: string, sourcePath?: string): void;
+export declare function subscribeOpenPencilSelection(sessionId: string, listener: () => void): () => void;
+export declare function getOpenPencilSelectionSnapshot(sessionId: string): OpenPencilSelectionStoreSnapshot;

--- a/lib/types/tool-names.d.ts
+++ b/lib/types/tool-names.d.ts
@@ -1,0 +1,12 @@
+/** Canonical model-facing OpenPencil tool names. */
+export declare const OPENPENCIL_RENDER_TOOL_NAME: "openpencil_render";
+export declare const OPENPENCIL_SELECTION_TOOL_NAME: "openpencil_selection";
+export declare const OPENPENCIL_CREATE_TOOL_NAME: "openpencil_create";
+export declare const OPENPENCIL_EDIT_TOOL_NAME: "openpencil_edit";
+/**
+ * Historical render name retained only by the browser presentation layer so
+ * existing conversation cards and details panels remain replayable. The host
+ * deliberately does not register this alias as a model-facing tool.
+ */
+export declare const LEGACY_DESIGN_RENDER_TOOL_NAME: "design_render";
+export declare const OPENPENCIL_TOOL_NAMES: readonly ["openpencil_render", "openpencil_selection", "openpencil_create", "openpencil_edit"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,14 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-client-locale": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-client-runtime": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-slots": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-theme": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-client-ui-tool": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-host-webserver": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-client-locale": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-client-runtime": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-slots": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.0.1-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.0.1-rc.2",
         "react": "^18.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "sync:viewer-assets": "node scripts/sync-viewer-assets.mjs",
     "test:viewer-assets": "node scripts/test-viewer-assets.mjs",
     "test:client": "npm run build:client && node --test tests/client.test.mjs",
+    "test:host-api": "npm run build && node --test tests/host-service.test.mjs tests/editor-host-lifecycle.test.mjs",
+    "test:mcp": "npm run build && node --test tests/mcp-client.test.mjs",
     "test:host": "npm run build && node scripts/test-host.mjs"
   },
   "dsh": {
@@ -56,6 +58,7 @@
       "inject": [
         "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-locale",
+        "@deepseek-ai/dsh-client-ui-conversation",
         "@deepseek-ai/dsh-client-ui-tool",
         "@deepseek-ai/dsh-client-ui-slots",
         "@deepseek-ai/dsh-client-ui-theme"
@@ -65,13 +68,14 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1-rc.1",
-    "@deepseek-ai/dsh-client-locale": "^0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-runtime": "^0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-ui-slots": "^0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-ui-theme": "^0.0.1-rc.1",
-    "@deepseek-ai/dsh-client-ui-tool": "^0.0.1-rc.1",
-    "@deepseek-ai/dsh-host-webserver": "^0.0.1-rc.1",
-    "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-client-locale": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-client-runtime": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-conversation": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-theme": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-client-ui-tool": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-host-webserver": "^0.0.1-rc.2",
+    "@deepseek-ai/dsh-tools": "^0.0.1-rc.2",
     "react": "^18.2.0"
   },
   "devDependencies": {

--- a/scripts/test-host.mjs
+++ b/scripts/test-host.mjs
@@ -31,6 +31,7 @@ const {
   EDITOR_ROUTE_PREFIX,
   EditorHostController,
 } = await import('../lib/editor-host.js')
+const { OPENPENCIL_RENDER_TOOL_NAME } = await import('../lib/tool-names.js')
 
 let server
 let editorHost
@@ -95,7 +96,7 @@ try {
     mimeType: 'image/png',
     kind: 'image',
     description: 'host smoke',
-    sourceTool: 'design_render',
+    sourceTool: OPENPENCIL_RENDER_TOOL_NAME,
     previewIntent: 'image',
     bytes: image.bytes,
     width: image.width,
@@ -177,6 +178,38 @@ try {
   assert.equal(launch.docJson, sourceBytes.toString('utf8'))
   const iframeResponse = await fetch(launch.iframeUrl)
   assert.equal(iframeResponse.status, 200)
+
+  // The managed editor is also the direct-drive target. Mirror one browser
+  // selection push, read it through the DSH proxy, then patch that selected
+  // node through first-party MCP and prove the live document changed.
+  const initialSelection = await editorHost.getActiveSelection()
+  assert.ok(typeof initialSelection.activePageId === 'string')
+  const selectedId = expectedFrames[0]?.id
+  assert.ok(typeof selectedId === 'string' && selectedId.length > 0)
+  const daemonOrigin = new URL(launch.iframeUrl).origin
+  const selectResponse = await fetch(`${daemonOrigin}/api/mcp/selection`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${launch.token}`,
+      'x-openpencil-token': launch.token,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ selectedIds: [selectedId], activePageId: initialSelection.activePageId }),
+  })
+  assert.equal(selectResponse.status, 200, await selectResponse.text())
+  const selected = await editorHost.getActiveSelection()
+  assert.deepEqual(selected.selectedIds, [selectedId])
+  assert.equal(selected.nodes[0]?.id, selectedId)
+  const selectionResponse = await fetch(`${origin}${launch.selectionUrl}`)
+  assert.equal(selectionResponse.status, 200)
+  assert.deepEqual((await selectionResponse.json()).selection.selectedIds, [selectedId])
+  await editorHost.callActiveMcp('update_node', {
+    nodeId: selectedId,
+    data: { name: 'DSH direct-drive smoke' },
+    ...(initialSelection.activePageId === '' ? {} : { pageId: initialSelection.activePageId }),
+  })
+  const changedSelection = await editorHost.getActiveSelection()
+  assert.equal(changedSelection.nodes[0]?.name, 'DSH direct-drive smoke')
 
   const saveBody = {
     sessionId: launch.sessionId,

--- a/src/client/details-compat.ts
+++ b/src/client/details-compat.ts
@@ -1,0 +1,44 @@
+/** Compatibility boundary for DSH builds before the keyed Tool details seam. */
+
+import type { ToolCallViewProps } from '@deepseek-ai/dsh-client-ui-tool/client'
+import type { DetailsToolOwnerProps } from '@deepseek-ai/dsh-client-ui-conversation/client'
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+
+/**
+ * rc.2 does not declare this slot. Declaring the same contract locally keeps
+ * the plugin type-safe on rc.2 and is identical to the declaration shipped by
+ * newer DSH builds. At runtime `slots.inject()` waits while a slot is absent,
+ * so no registration is attempted until a supporting DSH host declares it.
+ */
+declare module '@deepseek-ai/dsh-client-ui-slots' {
+  interface SlotMap {
+    'tool.details.toolview': {
+      kind: 'keyed'
+      scope: 'session'
+      owner: DetailsToolOwnerProps
+    }
+  }
+}
+
+/** Details props without importing a symbol absent from stock rc.2. */
+export type CompatibleToolDetailsViewProps = PropsRuntime<'tool.details.toolview'>
+
+/** Call props with the additive newer-DSH sidebar capability. */
+export type CompatibleToolCallViewProps = ToolCallViewProps & {
+  openDetails?: (() => void) | undefined
+}
+
+export type OpenPencilEditorSurface = 'details' | 'modal'
+
+/** Prefer the native resident details panel and otherwise open our own modal. */
+export function requestOpenPencilEditor(
+  openDetails: (() => void) | undefined,
+  openModal: () => void,
+): OpenPencilEditorSurface {
+  if (openDetails !== undefined) {
+    openDetails()
+    return 'details'
+  }
+  openModal()
+  return 'modal'
+}

--- a/src/client/editor-modal.tsx
+++ b/src/client/editor-modal.tsx
@@ -1,0 +1,128 @@
+/** Managed OpenPencil editor fallback for DSH builds without Tool details. */
+
+import { useCallback, useEffect, useId, useRef } from 'react'
+import type { PresentationGrant } from './index.js'
+import { confirmEditorClose, type EditorColorScheme, type EditorLocale } from './editor-bridge.js'
+import { ManagedOpenPencilEditor } from './editor-panel.js'
+
+interface EditorModalCopy {
+  title: string
+  close: string
+  discard: string
+}
+
+const EDITOR_MODAL_COPY: Record<EditorLocale, EditorModalCopy> = {
+  'zh-CN': {
+    title: 'OpenPencil 编辑器',
+    close: '关闭',
+    discard: 'OpenPencil 中有未保存的更改，确定关闭并放弃吗？',
+  },
+  'en-US': {
+    title: 'OpenPencil editor',
+    close: 'Close',
+    discard: 'OpenPencil has unsaved changes. Close and discard them?',
+  },
+}
+
+export function editorModalCopy(locale: EditorLocale): EditorModalCopy {
+  return EDITOR_MODAL_COPY[locale]
+}
+
+/** Read the editor's durable dirty marker before allowing the modal to close. */
+export function confirmEditorModalClose(
+  root: Pick<ParentNode, 'querySelector'> | null,
+  message: string,
+  confirm = window.confirm,
+): boolean {
+  const dirty = (root?.querySelector('[data-tool-details-dirty="true"]') ?? null) !== null
+  return confirmEditorClose(dirty, () => confirm(message))
+}
+
+const modalStyles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'fixed', inset: 0, zIndex: 2147483000,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    padding: 20, background: 'rgba(0,0,0,0.72)',
+  },
+  dialog: {
+    width: 'min(1440px, 96vw)', height: 'min(960px, 94vh)', minWidth: 0, minHeight: 0,
+    display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    border: '1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.5))', borderRadius: 10,
+    color: 'var(--dsw-alias-label-primary, #eee)', background: 'var(--dsw-alias-bg-base, #17171a)',
+    boxShadow: '0 24px 80px rgba(0,0,0,0.45)',
+  },
+  header: {
+    minHeight: 44, display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px',
+    borderBottom: '1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.3))',
+  },
+  title: {
+    minWidth: 0, marginRight: 'auto', overflow: 'hidden', textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap', fontSize: 13,
+  },
+  close: {
+    minHeight: 28, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    border: '1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.45))', borderRadius: 6,
+    color: 'var(--dsw-alias-label-primary, inherit)', background: 'var(--dsw-alias-bg-layer-1, transparent)',
+    padding: '4px 9px', cursor: 'pointer', font: 'inherit', fontSize: 12, lineHeight: 1,
+  },
+  body: { flex: 1, minHeight: 0, overflow: 'hidden' },
+}
+
+export function ManagedOpenPencilEditorModal({
+  grant,
+  colorScheme,
+  locale,
+  sessionId,
+  onClose,
+}: {
+  grant: PresentationGrant
+  colorScheme: EditorColorScheme
+  locale: EditorLocale
+  sessionId: string
+  onClose: () => void
+}) {
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const titleId = useId()
+  const copy = editorModalCopy(locale)
+
+  const requestClose = useCallback(() => {
+    if (!confirmEditorModalClose(bodyRef.current, copy.discard)) return
+    onClose()
+  }, [copy.discard, onClose])
+
+  useEffect(() => {
+    closeRef.current?.focus()
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      requestClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => { window.removeEventListener('keydown', onKeyDown) }
+  }, [requestClose])
+
+  return (
+    <div
+      style={modalStyles.backdrop}
+      role="presentation"
+      data-openpencil-editor-modal="true"
+      onMouseDown={(event) => { if (event.target === event.currentTarget) requestClose() }}
+    >
+      <section style={modalStyles.dialog} role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div style={modalStyles.header}>
+          <strong id={titleId} style={modalStyles.title}>{copy.title}</strong>
+          <button ref={closeRef} type="button" style={modalStyles.close} onClick={requestClose}>{copy.close}</button>
+        </div>
+        <div ref={bodyRef} style={modalStyles.body}>
+          <ManagedOpenPencilEditor
+            grant={grant}
+            colorScheme={colorScheme}
+            locale={locale}
+            sessionId={sessionId}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/client/editor-panel.tsx
+++ b/src/client/editor-panel.tsx
@@ -15,12 +15,19 @@ import {
   type EditorLocale,
 } from './editor-bridge.js'
 import { editorGrantForBoot, rememberEditorSuccessor } from './editor-successor.js'
+import {
+  clearOpenPencilSelection,
+  liveSelectionOf,
+  publishOpenPencilSelection,
+} from './selection-store.js'
+import { startEditorSelectionPolling } from './selection-polling.js'
 
 export interface LaunchResponse {
   sessionId: string
   iframeUrl: string
   token: string
   saveUrl: string
+  selectionUrl?: string
   closeUrl: string
   docJson?: string
   /** Client-only marker: the persisted launch capability was renewed. */
@@ -46,6 +53,9 @@ function launchResponseOf(value: unknown): LaunchResponse {
     iframeUrl: value.iframeUrl as string,
     token: value.token as string,
     saveUrl: editorControlUrl(value.saveUrl as string),
+    ...(typeof value.selectionUrl === 'string' && value.selectionUrl.length > 0
+      ? { selectionUrl: editorControlUrl(value.selectionUrl) }
+      : {}),
     closeUrl: editorControlUrl(value.closeUrl as string),
     ...(typeof value.docJson === 'string' ? { docJson: value.docJson } : {}),
   }
@@ -122,12 +132,23 @@ export function editorPanelCopy(locale: EditorLocale): EditorPanelCopy {
 interface EditorBootOptions {
   signal?: AbortSignal
   fetcher?: typeof fetch
+  sessionId?: string
 }
 
-function launchRequest(fetcher: typeof fetch, url: string, signal?: AbortSignal): Promise<Response> {
+interface EditorCloseOptions {
+  fetcher?: typeof fetch
+  dirty?: boolean
+  keepalive?: boolean
+}
+
+function launchRequest(fetcher: typeof fetch, url: string, signal?: AbortSignal, sessionId?: string): Promise<Response> {
   return fetcher(editorControlUrl(url), {
     method: 'POST',
     credentials: 'same-origin',
+    ...(sessionId === undefined ? {} : {
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId }),
+    }),
     ...(signal === undefined ? {} : { signal }),
   })
 }
@@ -145,7 +166,7 @@ export async function launchManagedEditor(
   const fetcher = options.fetcher ?? fetch
   let launchUrl = editor.launchUrl
   let renewed = false
-  let response = await launchRequest(fetcher, launchUrl, options.signal)
+  let response = await launchRequest(fetcher, launchUrl, options.signal, options.sessionId)
   if (response.status === 410) {
     if (document.path === undefined) {
       throw new Error('OpenPencil editor launch expired and cannot be refreshed without a source path')
@@ -166,7 +187,7 @@ export async function launchManagedEditor(
     renewed = true
     // One bounded retry only. A second 410 is surfaced by responseJson and
     // never loops back through refresh.
-    response = await launchRequest(fetcher, launchUrl, options.signal)
+    response = await launchRequest(fetcher, launchUrl, options.signal, options.sessionId)
   }
   const launch = launchResponseOf(await responseJson(response, 'OpenPencil editor launch'))
   return renewed ? { ...launch, renewed: true } : launch
@@ -180,16 +201,57 @@ export async function prepareManagedEditor(
 ): Promise<EditorBootResult> {
   const fetcher = options.fetcher ?? fetch
   const launch = await launchManagedEditor(editor, document, { ...options, fetcher })
-  if (launch.docJson !== undefined) return { launch, documentJson: launch.docJson }
-  if (editor.refreshUrl !== undefined || launch.renewed === true) {
-    throw new Error('OpenPencil editor launch omitted current docJson')
+  try {
+    if (launch.docJson !== undefined) return { launch, documentJson: launch.docJson }
+    if (editor.refreshUrl !== undefined || launch.renewed === true) {
+      throw new Error('OpenPencil editor launch omitted current docJson')
+    }
+    const documentResponse = await fetcher(editorControlUrl(document.url), {
+      credentials: 'same-origin',
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+    })
+    if (!documentResponse.ok) throw new Error(`OpenPencil document request failed (${documentResponse.status})`)
+    return { launch, documentJson: await documentResponse.text() }
+  } catch (error) {
+    // The daemon already exists once launchManagedEditor returns. A cancelled
+    // fallback document fetch or contract error must not strand that process.
+    await closeManagedEditorLaunch(launch, { fetcher, keepalive: true })
+    throw error
   }
-  const documentResponse = await fetcher(editorControlUrl(document.url), {
+}
+
+/** Close exactly the managed session returned by one launch response. */
+export async function closeManagedEditorLaunch(
+  launch: LaunchResponse,
+  options: EditorCloseOptions = {},
+): Promise<void> {
+  const fetcher = options.fetcher ?? fetch
+  await fetcher(launch.closeUrl, {
+    method: 'DELETE',
     credentials: 'same-origin',
-    ...(options.signal === undefined ? {} : { signal: options.signal }),
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ sessionId: launch.sessionId, dirty: options.dirty ?? false }),
+    ...(options.keepalive === undefined ? {} : { keepalive: options.keepalive }),
+  }).catch(() => {})
+}
+
+/**
+ * Mount-aware boot boundary. React may cancel an effect after its launch POST
+ * has committed; release that precise returned session before ignoring it.
+ */
+export async function prepareManagedEditorForMount(
+  editor: NonNullable<PresentationGrant['editor']>,
+  document: NonNullable<PresentationGrant['document']>,
+  accept: () => boolean,
+  options: EditorBootOptions = {},
+): Promise<EditorBootResult | undefined> {
+  const prepared = await prepareManagedEditor(editor, document, options)
+  if (accept()) return prepared
+  await closeManagedEditorLaunch(prepared.launch, {
+    ...(options.fetcher === undefined ? {} : { fetcher: options.fetcher }),
+    keepalive: true,
   })
-  if (!documentResponse.ok) throw new Error(`OpenPencil document request failed (${documentResponse.status})`)
-  return { launch, documentJson: await documentResponse.text() }
+  return undefined
 }
 
 const panelStyles: Record<string, React.CSSProperties> = {
@@ -221,10 +283,11 @@ const panelStyles: Record<string, React.CSSProperties> = {
 type Phase = 'launching' | 'loading' | 'ready' | 'saving' | 'error'
 
 /** Editable panel. The daemon is created lazily only while this component is mounted. */
-export function ManagedOpenPencilEditor({ grant, colorScheme, locale }: {
+export function ManagedOpenPencilEditor({ grant, colorScheme, locale, sessionId }: {
   grant: PresentationGrant
   colorScheme: EditorColorScheme
   locale: EditorLocale
+  sessionId: string
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const launchRef = useRef<LaunchResponse>()
@@ -236,6 +299,7 @@ export function ManagedOpenPencilEditor({ grant, colorScheme, locale }: {
   const localeRef = useRef(locale)
   localeRef.current = locale
   const initTimerRef = useRef<ReturnType<typeof setInterval>>()
+  const selectionPollStopRef = useRef<() => void>()
   const requestCounterRef = useRef(0)
   const saveWaitersRef = useRef(new Map<string, { resolve: (message: Extract<EditorInboundMessage, { type: 'op-bridge/snapshot-result' }>) => void; reject: (error: Error) => void }>())
   const [phase, setPhase] = useState<Phase>('launching')
@@ -291,15 +355,13 @@ export function ManagedOpenPencilEditor({ grant, colorScheme, locale }: {
     const abort = new AbortController()
     const coordinatorToken = Symbol('openpencil-editor')
     const closeDaemon = async (dirtyAtClose = dirtyRef.current): Promise<void> => {
+      selectionPollStopRef.current?.()
+      selectionPollStopRef.current = undefined
+      clearOpenPencilSelection(sessionId, documentGrant.path)
       const launch = launchRef.current
       if (launch === undefined) return
       launchRef.current = undefined
-      await fetch(launch.closeUrl, {
-        method: 'DELETE', credentials: 'same-origin',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ sessionId: launch.sessionId, dirty: dirtyAtClose }),
-        keepalive: true,
-      }).catch(() => {})
+      await closeManagedEditorLaunch(launch, { dirty: dirtyAtClose, keepalive: true })
     }
     const releaseEditor = claimEditor(coordinatorToken, () => {
       abort.abort()
@@ -308,11 +370,16 @@ export function ManagedOpenPencilEditor({ grant, colorScheme, locale }: {
     const boot = async (): Promise<void> => {
       try {
         const bootGrant = editorGrantForBoot(editorGrant)
-        const { launch, documentJson } = await prepareManagedEditor(bootGrant, documentGrant, {
-          signal: abort.signal,
+        const prepared = await prepareManagedEditorForMount(bootGrant, documentGrant, () => (
+          !cancelled && !abort.signal.aborted
+        ), {
+          sessionId,
         })
+        if (prepared === undefined) return
+        const { launch, documentJson } = prepared
         const origin = editorOrigin(launch.iframeUrl)
-        if (cancelled) return
+        // No await occurs between acceptance and publication. Cleanup can now
+        // find this session in launchRef and cannot target a later launch.
         launchRef.current = launch
         // Capture first-navigation host presentation exactly once. Later host
         // theme/locale changes travel over the bridge and never reload the iframe.
@@ -341,6 +408,26 @@ export function ManagedOpenPencilEditor({ grant, colorScheme, locale }: {
       void closeDaemon()
     }
   }, [documentGrant.path, documentGrant.url, editorGrant.launchUrl, editorGrant.refreshUrl])
+
+  useEffect(() => {
+    if (phase !== 'ready' && phase !== 'saving') return
+    const selectionUrl = launchRef.current?.selectionUrl
+    if (selectionUrl === undefined) return
+    const stop = startEditorSelectionPolling({
+      url: selectionUrl,
+      onValue: value => {
+        if (!isRecord(value)) return
+        const selection = liveSelectionOf(value.selection)
+        if (selection !== undefined) publishOpenPencilSelection(sessionId, selection)
+      },
+      onStop: () => { clearOpenPencilSelection(sessionId, documentGrant.path) },
+    })
+    selectionPollStopRef.current = stop
+    return () => {
+      if (selectionPollStopRef.current === stop) selectionPollStopRef.current = undefined
+      stop()
+    }
+  }, [documentGrant.path, phase, sessionId])
 
   useEffect(() => {
     const listener = (event: MessageEvent): void => {

--- a/src/client/frame-gallery.tsx
+++ b/src/client/frame-gallery.tsx
@@ -165,6 +165,14 @@ export const GALLERY_TOOLBAR_CONTROL_LAYOUT: Readonly<React.CSSProperties> = Obj
   verticalAlign: 'middle',
 })
 
+/** Optical correction for CJK labels and +/- glyphs inside the centered control box. */
+export const GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT: Readonly<React.CSSProperties> = Object.freeze({
+  display: 'inline-block',
+  lineHeight: 1,
+  transform: 'translateY(-1px)',
+  pointerEvents: 'none',
+})
+
 export function galleryViewportMaxHeight(fitContent: boolean): number | undefined {
   return fitContent ? undefined : GALLERY_COMPACT_MAX_HEIGHT
 }
@@ -191,8 +199,10 @@ const styles: Record<string, React.CSSProperties> = {
     minWidth: GALLERY_TOOLBAR_CONTROL_HEIGHT, padding: '0 8px', borderRadius: 5,
     border: '1px solid var(--ui-border, rgba(128,128,128,0.35))',
     color: 'var(--ui-text, inherit)', background: 'var(--ui-card-bg, rgba(128,128,128,0.08))', cursor: 'pointer',
-    font: 'inherit', fontSize: 12, lineHeight: 1, whiteSpace: 'nowrap',
+    fontFamily: 'inherit', fontWeight: 'inherit', fontStyle: 'inherit',
+    fontSize: 12, lineHeight: 1, whiteSpace: 'nowrap',
   },
+  controlContent: GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT,
   zoomPercent: {
     ...GALLERY_TOOLBAR_CONTROL_LAYOUT,
     minWidth: 42, padding: '0 3px', textAlign: 'center',
@@ -217,7 +227,7 @@ const styles: Record<string, React.CSSProperties> = {
     width: GALLERY_TOOLBAR_CONTROL_HEIGHT, minWidth: GALLERY_TOOLBAR_CONTROL_HEIGHT, padding: 0, borderRadius: 99,
     border: '1px solid var(--ui-border, rgba(128,128,128,0.35))',
     color: 'var(--ui-text, inherit)', background: 'var(--ui-card-bg, rgba(128,128,128,0.08))',
-    cursor: 'pointer', font: 'inherit', fontSize: 20, lineHeight: 1,
+    cursor: 'pointer', fontFamily: 'inherit', fontWeight: 'inherit', fontStyle: 'inherit', fontSize: 20, lineHeight: 1,
   },
   strip: {
     display: 'flex', gap: 8, minWidth: 0, overflowX: 'auto', overflowY: 'hidden',
@@ -379,8 +389,10 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
               aria-label={copy.zoomOut}
               title={copy.zoomOutTitle}
               onClick={() => { setZoom(nextGalleryZoom(zoom, -1)) }}
-            >−</button>
-            <output style={styles.zoomPercent} aria-label={`${copy.previewZoom} ${zoomLabel}`} aria-live="polite">{zoomLabel}</output>
+            ><span style={styles.controlContent}>−</span></button>
+            <output style={styles.zoomPercent} aria-label={`${copy.previewZoom} ${zoomLabel}`} aria-live="polite">
+              <span style={styles.controlContent}>{zoomLabel}</span>
+            </output>
             <button
               type="button"
               style={{ ...styles.zoomButton, opacity: canZoomIn ? 1 : 0.42 }}
@@ -388,7 +400,7 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
               aria-label={copy.zoomIn}
               title={copy.zoomInTitle}
               onClick={() => { setZoom(nextGalleryZoom(zoom, 1)) }}
-            >+</button>
+            ><span style={styles.controlContent}>+</span></button>
             <button
               type="button"
               style={{ ...styles.zoomButton, opacity: zoomMode === 'manual' && manualZoom === 1 ? 0.42 : 1 }}
@@ -396,7 +408,7 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
               aria-label={copy.resetAria}
               title={copy.resetTitle}
               onClick={resetZoom}
-            >{copy.reset}</button>
+            ><span style={styles.controlContent}>{copy.reset}</span></button>
             <button
               type="button"
               style={{
@@ -418,7 +430,7 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
                 viewport?.scrollTo({ left: 0, top: 0 })
               }}
               data-openpencil-fit-view="true"
-            >{copy.fitFrame}</button>
+            ><span style={styles.controlContent}>{copy.fitFrame}</span></button>
             <button
               type="button"
               style={{
@@ -438,7 +450,7 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
                 viewportRef.current?.scrollTo({ left: 0, top: 0 })
               }}
               data-openpencil-card-height-toggle="true"
-            >{fitContent ? copy.restoreCard : copy.fitContent}</button>
+            ><span style={styles.controlContent}>{fitContent ? copy.restoreCard : copy.fitContent}</span></button>
           </div>
           {frames.length > 1 ? (
             <>
@@ -449,7 +461,7 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
                 aria-label={copy.previous}
                 title={copy.previous}
                 onClick={() => { select(currentIndex - 1) }}
-              >‹</button>
+              ><span style={styles.controlContent}>‹</span></button>
               <button
                 type="button"
                 style={{ ...styles.arrow, opacity: currentIndex === frames.length - 1 ? 0.42 : 1 }}
@@ -457,7 +469,7 @@ export function FrameGallery({ frames, selectedIndex, onSelect, locale }: FrameG
                 aria-label={copy.next}
                 title={copy.next}
                 onClick={() => { select(currentIndex + 1) }}
-              >›</button>
+              ><span style={styles.controlContent}>›</span></button>
             </>
           ) : null}
         </div>

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,5 +1,6 @@
 /**
- * Browser presentation for `design_render`.
+ * Browser presentation for `openpencil_render` and historical
+ * `design_render` conversation cards.
  *
  * PNG remains the replay-safe default. When the host also grants access to
  * the source `.op`, the user can opt into one shared, read-only Web SDK
@@ -17,11 +18,22 @@ import type { PointerEvent as ReactPointerEvent } from 'react'
 import type { ToolCallViewProps, ToolDetailsViewProps } from '@deepseek-ai/dsh-client-ui-tool/client'
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import type {} from '@deepseek-ai/dsh-client-locale/client'
+import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
 import type {} from '@deepseek-ai/dsh-client-ui-theme/client'
 import { editorPanelCopy, ManagedOpenPencilEditor } from './editor-panel.js'
 import { editorLocaleFromDsh, type EditorColorScheme, type EditorLocale } from './editor-bridge.js'
 import { FrameGallery, normalizeFrameIndex as normalizedFrameIndex } from './frame-gallery.js'
 import type { GalleryFrame, GalleryLocale } from './frame-gallery.js'
+import { OpenPencilSelectionDock } from './selection-dock.js'
+import {
+  LEGACY_DESIGN_RENDER_TOOL_NAME,
+  OPENPENCIL_RENDER_TOOL_NAME,
+} from '../tool-names.js'
+
+export {
+  LEGACY_DESIGN_RENDER_TOOL_NAME,
+  OPENPENCIL_RENDER_TOOL_NAME,
+} from '../tool-names.js'
 
 export {
   calculateGalleryFitViewZoom,
@@ -33,6 +45,7 @@ export {
   galleryZoomPercent,
   galleryZoomShortcut,
   GALLERY_COMPACT_MAX_HEIGHT,
+  GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT,
   GALLERY_TOOLBAR_CONTROL_HEIGHT,
   GALLERY_TOOLBAR_CONTROL_LAYOUT,
   GALLERY_ZOOM_MAX,
@@ -41,7 +54,13 @@ export {
   nextGalleryZoom,
   normalizeFrameIndex,
 } from './frame-gallery.js'
-export { editorPanelCopy, launchManagedEditor, prepareManagedEditor } from './editor-panel.js'
+export {
+  closeManagedEditorLaunch,
+  editorPanelCopy,
+  launchManagedEditor,
+  prepareManagedEditor,
+  prepareManagedEditorForMount,
+} from './editor-panel.js'
 export {
   editorGrantForBoot,
   editorSuccessorFromSave,
@@ -61,6 +80,23 @@ export {
   encodeEditorOutbound,
   parseEditorInbound,
 } from './editor-bridge.js'
+export {
+  clearOpenPencilSelection,
+  getOpenPencilSelectionSnapshot,
+  liveSelectionOf,
+  publishOpenPencilSelection,
+  subscribeOpenPencilSelection,
+} from './selection-store.js'
+export {
+  isTerminalEditorSelectionStatus,
+  startEditorSelectionPolling,
+} from './selection-polling.js'
+export {
+  hasOpenPencilSelection,
+  OPENPENCIL_SELECTION_DOCK_LAYOUT,
+  selectionNodeDetail,
+  selectionNodeLabel,
+} from './selection-dock.js'
 
 /** Presentation metadata key the host half projects into `block.meta`. */
 export const PRESENTATION_META_KEY = '$dshOpenPencil'
@@ -69,7 +105,7 @@ export type PresentationLocale = GalleryLocale
 
 const DESIGN_RENDER_COPY = {
   en: {
-    designRender: 'Design render',
+    designRender: 'OpenPencil render',
     error: 'error',
     rendering: 'rendering…',
     done: 'done',
@@ -99,7 +135,7 @@ const DESIGN_RENDER_COPY = {
     editorUnavailable: 'Editable OpenPencil canvas is not available for this result.',
   },
   zh: {
-    designRender: '设计渲染',
+    designRender: 'OpenPencil 渲染',
     error: '错误',
     rendering: '渲染中…',
     done: '完成',
@@ -604,7 +640,7 @@ function CanvasModal({ grant, onClose, locale }: {
   )
 }
 
-/** Render one `design_render` tool call as a PNG-first card. */
+/** Render one OpenPencil render tool call as a PNG-first card. */
 export function DesignRenderView({ block, openDetails, openFile, inspect, locale = 'en' }: ToolCallViewProps & {
   locale?: PresentationLocale
 }) {
@@ -646,7 +682,7 @@ export function DesignRenderView({ block, openDetails, openFile, inspect, locale
       : <span style={{ ...styles.badge, ...styles.badgeOk }}>{copy.done}</span>
 
   return (
-    <section style={styles.card} data-tool="design_render" data-state={error ? 'error' : running ? 'running' : 'success'}>
+    <section style={styles.card} data-tool={OPENPENCIL_RENDER_TOOL_NAME} data-state={error ? 'error' : running ? 'running' : 'success'}>
       <div style={styles.head}><span>{copy.designRender}</span>{badge}</div>
       <div style={styles.body}>
         {running ? <p style={styles.muted}>{copy.renderingDocument}</p> : null}
@@ -687,7 +723,7 @@ export function DesignRenderView({ block, openDetails, openFile, inspect, locale
 }
 
 /** Render the selected editable design inside DSH's resident details column. */
-export function OpenPencilEditorPanel({ block, colorScheme, locale }: ToolDetailsViewProps & {
+export function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }: ToolDetailsViewProps & {
   colorScheme: EditorColorScheme
   locale: EditorLocale
 }) {
@@ -695,13 +731,13 @@ export function OpenPencilEditorPanel({ block, colorScheme, locale }: ToolDetail
   if (grant?.editor === undefined || grant.document === undefined) {
     return <div style={styles.overlay}>{editorPanelCopy(locale).unavailable}</div>
   }
-  return <ManagedOpenPencilEditor grant={grant} colorScheme={colorScheme} locale={locale} />
+  return <ManagedOpenPencilEditor grant={grant} colorScheme={colorScheme} locale={locale} sessionId={String(sessionId)} />
 }
 
 /** Required client services. */
 export const inject = ['slots', 'theme', 'locale']
 
-/** Register the dedicated toolview for `design_render`. */
+/** Register canonical views plus a presentation-only alias for replaying historical cards. */
 export function apply(ctx: ClientContext): void {
   const subscribeTheme = (notify: () => void): (() => boolean) => ctx.on('theme/change', notify)
   const getColorScheme = (): EditorColorScheme => ctx.theme.getTheme().active.colorScheme
@@ -717,12 +753,22 @@ export function apply(ctx: ClientContext): void {
     const locale = useSyncExternalStore(subscribeLocale, getEditorLocale, getEditorLocale)
     return <OpenPencilEditorPanel {...props} colorScheme={colorScheme} locale={locale} />
   }
-  ctx.slots.inject('tool.call.toolview', () => ctx.slots.register(
-    { name: 'tool.call.toolview', key: 'design_render' },
-    HostSyncedDesignRenderView,
-  ))
-  ctx.slots.inject('tool.details.toolview', () => ctx.slots.register(
-    { name: 'tool.details.toolview', key: 'design_render' },
-    HostSyncedOpenPencilEditorPanel,
+  const HostSyncedOpenPencilSelectionDock = (props: Omit<React.ComponentProps<typeof OpenPencilSelectionDock>, 'locale'>): React.JSX.Element => {
+    const locale = useSyncExternalStore(subscribeLocale, getLocale, getLocale)
+    return <OpenPencilSelectionDock {...props} locale={locale} />
+  }
+  for (const toolName of [OPENPENCIL_RENDER_TOOL_NAME, LEGACY_DESIGN_RENDER_TOOL_NAME]) {
+    ctx.slots.inject('tool.call.toolview', () => ctx.slots.register(
+      { name: 'tool.call.toolview', key: toolName },
+      HostSyncedDesignRenderView,
+    ))
+    ctx.slots.inject('tool.details.toolview', () => ctx.slots.register(
+      { name: 'tool.details.toolview', key: toolName },
+      HostSyncedOpenPencilEditorPanel,
+    ))
+  }
+  ctx.slots.inject('conversation.input.dock', () => ctx.slots.register(
+    { name: 'conversation.input.dock', id: 'openpencil-selection', order: 30 },
+    HostSyncedOpenPencilSelectionDock,
   ))
 }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -15,13 +15,19 @@ import {
   useSyncExternalStore,
 } from 'react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
-import type { ToolCallViewProps, ToolDetailsViewProps } from '@deepseek-ai/dsh-client-ui-tool/client'
+import type { ToolCallViewProps } from '@deepseek-ai/dsh-client-ui-tool/client'
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import type {} from '@deepseek-ai/dsh-client-locale/client'
 import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
 import type {} from '@deepseek-ai/dsh-client-ui-theme/client'
 import { editorPanelCopy, ManagedOpenPencilEditor } from './editor-panel.js'
 import { editorLocaleFromDsh, type EditorColorScheme, type EditorLocale } from './editor-bridge.js'
+import {
+  requestOpenPencilEditor,
+  type CompatibleToolCallViewProps,
+  type CompatibleToolDetailsViewProps,
+} from './details-compat.js'
+import { ManagedOpenPencilEditorModal } from './editor-modal.js'
 import { FrameGallery, normalizeFrameIndex as normalizedFrameIndex } from './frame-gallery.js'
 import type { GalleryFrame, GalleryLocale } from './frame-gallery.js'
 import { OpenPencilSelectionDock } from './selection-dock.js'
@@ -61,6 +67,13 @@ export {
   prepareManagedEditor,
   prepareManagedEditorForMount,
 } from './editor-panel.js'
+export {
+  requestOpenPencilEditor,
+} from './details-compat.js'
+export {
+  confirmEditorModalClose,
+  editorModalCopy,
+} from './editor-modal.js'
 export {
   editorGrantForBoot,
   editorSuccessorFromSave,
@@ -113,6 +126,7 @@ const DESIGN_RENDER_COPY = {
     renderFailed: 'The render failed.',
     frames: 'frames',
     openInteractiveCanvas: 'Open interactive canvas',
+    editCanvas: 'Edit canvas',
     editInSidebar: 'Edit in sidebar',
     openRenderedPng: 'Open rendered PNG',
     downloadPng: 'Download PNG',
@@ -143,6 +157,7 @@ const DESIGN_RENDER_COPY = {
     renderFailed: '渲染失败。',
     frames: '页',
     openInteractiveCanvas: '打开交互画布',
+    editCanvas: '编辑画布',
     editInSidebar: '在侧边栏编辑',
     openRenderedPng: '打开渲染 PNG',
     downloadPng: '下载 PNG',
@@ -641,8 +656,19 @@ function CanvasModal({ grant, onClose, locale }: {
 }
 
 /** Render one OpenPencil render tool call as a PNG-first card. */
-export function DesignRenderView({ block, openDetails, openFile, inspect, locale = 'en' }: ToolCallViewProps & {
+export function DesignRenderView({
+  block,
+  openDetails,
+  openFile,
+  inspect,
+  locale = 'en',
+  colorScheme = 'light',
+  editorLocale,
+  sessionId,
+}: CompatibleToolCallViewProps & {
   locale?: PresentationLocale
+  colorScheme?: EditorColorScheme
+  editorLocale?: EditorLocale
 }) {
   const settled = 'kind' in block
   const error = settled && block.isError
@@ -655,7 +681,9 @@ export function DesignRenderView({ block, openDetails, openFile, inspect, locale
   const currentFrameIndex = normalizedFrameIndex(selectedFrameIndex, frames.length)
   const selectedFrame = frames[currentFrameIndex] ?? grant?.image
   const [modalToken, setModalToken] = useState<symbol>()
+  const [editorModalOpen, setEditorModalOpen] = useState(false)
   const releaseRef = useRef<() => void>()
+  const resolvedEditorLocale = editorLocale ?? editorLocaleFromDsh(locale)
 
   const closeCanvas = useCallback(() => {
     releaseRef.current?.()
@@ -671,6 +699,10 @@ export function DesignRenderView({ block, openDetails, openFile, inspect, locale
     })
     setModalToken(token)
   }, [])
+
+  const openEditor = useCallback(() => {
+    requestOpenPencilEditor(openDetails, () => { setEditorModalOpen(true) })
+  }, [openDetails])
 
   useEffect(() => () => { releaseRef.current?.() }, [])
   useEffect(() => { setSelectedFrameIndex(0) }, [frames.map(frame => frame.previewUrl).join('\n')])
@@ -701,7 +733,11 @@ export function DesignRenderView({ block, openDetails, openFile, inspect, locale
               <span title={grant.rendererBinary}>{grant.renderer}{grant.fidelity === undefined ? '' : ` · ${grant.fidelity}`}</span>
             ) : null}
             {grant.document !== undefined && grant.viewer !== undefined ? <button type="button" style={styles.primaryButton} onClick={openCanvas}>{copy.openInteractiveCanvas}</button> : null}
-            {grant.document !== undefined && grant.editor?.enabled === true ? <button type="button" style={styles.primaryButton} onClick={openDetails}>{copy.editInSidebar}</button> : null}
+            {grant.document !== undefined && grant.editor?.enabled === true ? (
+              <button type="button" style={styles.primaryButton} onClick={openEditor}>
+                {openDetails === undefined ? copy.editCanvas : copy.editInSidebar}
+              </button>
+            ) : null}
             {selectedFrame !== undefined && openFile !== undefined ? (
               <button type="button" style={styles.button} onClick={() => { openFile(selectedFrame.path) }}>{copy.openRenderedPng}</button>
             ) : null}
@@ -718,12 +754,21 @@ export function DesignRenderView({ block, openDetails, openFile, inspect, locale
         ) : null}
       </div>
       {modalToken !== undefined && grant?.document !== undefined && grant.viewer !== undefined ? <CanvasModal grant={grant} onClose={closeCanvas} locale={locale} /> : null}
+      {editorModalOpen && grant?.document !== undefined && grant.editor?.enabled === true ? (
+        <ManagedOpenPencilEditorModal
+          grant={grant}
+          colorScheme={colorScheme}
+          locale={resolvedEditorLocale}
+          sessionId={String(sessionId)}
+          onClose={() => { setEditorModalOpen(false) }}
+        />
+      ) : null}
     </section>
   )
 }
 
 /** Render the selected editable design inside DSH's resident details column. */
-export function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }: ToolDetailsViewProps & {
+export function OpenPencilEditorPanel({ block, colorScheme, locale, sessionId }: CompatibleToolDetailsViewProps & {
   colorScheme: EditorColorScheme
   locale: EditorLocale
 }) {
@@ -746,9 +791,17 @@ export function apply(ctx: ClientContext): void {
   const getEditorLocale = (): EditorLocale => editorLocaleFromDsh(getLocale())
   const HostSyncedDesignRenderView = (props: ToolCallViewProps): React.JSX.Element => {
     const locale = useSyncExternalStore(subscribeLocale, getLocale, getLocale)
-    return <DesignRenderView {...props} locale={locale} />
+    const colorScheme = useSyncExternalStore(subscribeTheme, getColorScheme, getColorScheme)
+    return (
+      <DesignRenderView
+        {...props}
+        locale={locale}
+        editorLocale={editorLocaleFromDsh(locale)}
+        colorScheme={colorScheme}
+      />
+    )
   }
-  const HostSyncedOpenPencilEditorPanel = (props: ToolDetailsViewProps): React.JSX.Element => {
+  const HostSyncedOpenPencilEditorPanel = (props: CompatibleToolDetailsViewProps): React.JSX.Element => {
     const colorScheme = useSyncExternalStore(subscribeTheme, getColorScheme, getColorScheme)
     const locale = useSyncExternalStore(subscribeLocale, getEditorLocale, getEditorLocale)
     return <OpenPencilEditorPanel {...props} colorScheme={colorScheme} locale={locale} />

--- a/src/client/selection-dock.tsx
+++ b/src/client/selection-dock.tsx
@@ -1,0 +1,89 @@
+/** Live OpenPencil selection chip rendered above the DSH composer. */
+
+import { useCallback, useSyncExternalStore } from 'react'
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
+import {
+  getOpenPencilSelectionSnapshot,
+  subscribeOpenPencilSelection,
+  type OpenPencilLiveSelection,
+} from './selection-store.js'
+import type { PresentationLocale } from './index.js'
+
+export const OPENPENCIL_SELECTION_DOCK_LAYOUT = {
+  boxSizing: 'border-box',
+  flex: 'none',
+  width: 'calc(100% - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))',
+  maxWidth: 'calc(var(--dsh-composer-card-max-width, 780px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))',
+  margin: '0 auto',
+} as const satisfies React.CSSProperties
+
+export function hasOpenPencilSelection(
+  selection: OpenPencilLiveSelection | undefined,
+): selection is OpenPencilLiveSelection {
+  return (selection?.selectedIds.length ?? 0) > 0
+}
+
+export function selectionNodeLabel(selection: OpenPencilLiveSelection, locale: PresentationLocale): string {
+  if (selection.selectedIds.length === 0) return locale === 'zh' ? '未选择画布节点' : 'No canvas node selected'
+  if (selection.selectedIds.length > 1) {
+    return locale === 'zh' ? `已选择 ${selection.selectedIds.length} 个节点` : `${selection.selectedIds.length} nodes selected`
+  }
+  const node = selection.nodes[0]
+  return node?.name ?? node?.type ?? selection.selectedIds[0]!
+}
+
+export function selectionNodeDetail(selection: OpenPencilLiveSelection, locale: PresentationLocale): string {
+  if (selection.selectedIds.length === 0) return locale === 'zh' ? '在右侧 OpenPencil 画布中选择节点' : 'Select a node on the OpenPencil canvas'
+  const node = selection.nodes[0]
+  if (selection.selectedIds.length > 1 || node === undefined) return selection.selectedIds.slice(0, 3).join(' · ')
+  const dimensions = node.width === undefined || node.height === undefined
+    ? undefined
+    : `${Math.round(node.width)} × ${Math.round(node.height)}`
+  return [node.type, dimensions, node.id].filter(Boolean).join(' · ')
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: {
+    ...OPENPENCIL_SELECTION_DOCK_LAYOUT,
+    display: 'flex', alignItems: 'center', gap: 10, minHeight: 42,
+    padding: '7px 10px', border: '1px solid var(--dsw-alias-border-l2)',
+    borderRadius: 9, background: 'var(--dsw-alias-bg-layer-1)', color: 'var(--dsw-alias-label-primary)',
+  },
+  icon: {
+    width: 28, height: 28, flex: '0 0 28px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    borderRadius: 7, background: 'var(--dsw-alias-brand-primary, #3b82f6)', color: '#fff', fontSize: 15,
+  },
+  text: { minWidth: 0, display: 'flex', flexDirection: 'column', gap: 1 },
+  title: { fontSize: 12, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  detail: { fontSize: 11, color: 'var(--dsw-alias-label-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  target: { marginLeft: 'auto', fontSize: 11, color: 'var(--dsw-alias-label-secondary)', whiteSpace: 'nowrap' },
+}
+
+export type OpenPencilSelectionDockProps = PropsRuntime<'conversation.input.dock'> & {
+  locale: PresentationLocale
+}
+
+export function OpenPencilSelectionDock({ sessionId, locale }: OpenPencilSelectionDockProps) {
+  const subscribe = useCallback(
+    (notify: () => void) => subscribeOpenPencilSelection(String(sessionId), notify),
+    [sessionId],
+  )
+  const getSnapshot = useCallback(
+    () => getOpenPencilSelectionSnapshot(String(sessionId)),
+    [sessionId],
+  )
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const selection = snapshot.selection
+  if (!hasOpenPencilSelection(selection)) return null
+  return (
+    <div style={styles.root} data-openpencil-selection-dock="true" role="status">
+      <span style={styles.icon} aria-hidden="true">◇</span>
+      <span style={styles.text}>
+        <span style={styles.title}>{selectionNodeLabel(selection, locale)}</span>
+        <span style={styles.detail}>{selectionNodeDetail(selection, locale)}</span>
+      </span>
+      <span style={styles.target}>{locale === 'zh' ? 'OpenPencil 修改目标' : 'OpenPencil edit target'}</span>
+    </div>
+  )
+}

--- a/src/client/selection-polling.ts
+++ b/src/client/selection-polling.ts
@@ -1,0 +1,93 @@
+/** Lifecycle-safe polling for the optional OpenPencil live-selection endpoint. */
+
+export interface SelectionPollTimer {
+  schedule(callback: () => void, delayMs: number): unknown
+  cancel(handle: unknown): void
+}
+
+export interface EditorSelectionPollingOptions {
+  url: string
+  onValue(value: unknown): void
+  onStop(): void
+  fetcher?: typeof fetch
+  intervalMs?: number
+  timer?: SelectionPollTimer
+}
+
+const DEFAULT_INTERVAL_MS = 400
+
+const DEFAULT_TIMER: SelectionPollTimer = {
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: handle => { clearTimeout(handle as ReturnType<typeof setTimeout>) },
+}
+
+/** Client failures other than retry-oriented HTTP statuses cannot recover by polling. */
+export function isTerminalEditorSelectionStatus(status: number): boolean {
+  return status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429
+}
+
+/**
+ * Start one immediate poll followed by non-overlapping delayed polls.
+ *
+ * The returned cleanup is idempotent, aborts an in-flight request, cancels the
+ * pending timer, and invokes `onStop` exactly once. Terminal HTTP responses
+ * use the same cleanup path; network errors and retryable statuses schedule a
+ * later attempt without disrupting the editor itself.
+ */
+export function startEditorSelectionPolling(options: EditorSelectionPollingOptions): () => void {
+  const fetcher = options.fetcher ?? fetch
+  const timer = options.timer ?? DEFAULT_TIMER
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS
+  let stopped = false
+  let timerHandle: unknown
+  let requestAbort: AbortController | undefined
+
+  const stop = (): void => {
+    if (stopped) return
+    stopped = true
+    if (timerHandle !== undefined) {
+      timer.cancel(timerHandle)
+      timerHandle = undefined
+    }
+    requestAbort?.abort()
+    requestAbort = undefined
+    options.onStop()
+  }
+
+  const schedule = (): void => {
+    if (stopped) return
+    timerHandle = timer.schedule(() => {
+      timerHandle = undefined
+      void poll()
+    }, intervalMs)
+  }
+
+  const poll = async (): Promise<void> => {
+    if (stopped) return
+    const abort = new AbortController()
+    requestAbort = abort
+    try {
+      const response = await fetcher(options.url, {
+        credentials: 'same-origin',
+        signal: abort.signal,
+      })
+      if (stopped) return
+      if (isTerminalEditorSelectionStatus(response.status)) {
+        stop()
+        return
+      }
+      if (response.ok) {
+        const value: unknown = await response.json()
+        if (!stopped) options.onValue(value)
+      }
+    } catch {
+      // Selection is an enhancement. Transient transport failures retry later.
+    } finally {
+      if (requestAbort === abort) requestAbort = undefined
+      schedule()
+    }
+  }
+
+  void poll()
+  return stop
+}

--- a/src/client/selection-store.ts
+++ b/src/client/selection-store.ts
@@ -1,0 +1,108 @@
+/** Page-local live selection store shared by the sidebar and conversation. */
+
+export interface OpenPencilNodeSelection {
+  id: string
+  type?: string
+  name?: string
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+}
+
+export interface OpenPencilLiveSelection {
+  sourcePath: string
+  activePageId: string
+  selectedIds: string[]
+  nodes: OpenPencilNodeSelection[]
+  updatedAt: number
+}
+
+export interface OpenPencilSelectionStoreSnapshot {
+  revision: number
+  selection?: OpenPencilLiveSelection
+}
+
+const stores = new Map<string, OpenPencilSelectionStoreSnapshot>()
+const listeners = new Map<string, Set<() => void>>()
+const EMPTY_SELECTION_STORE_SNAPSHOT: OpenPencilSelectionStoreSnapshot = Object.freeze({ revision: 0 })
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function finite(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function nodeOf(value: unknown): OpenPencilNodeSelection | undefined {
+  if (!isRecord(value) || typeof value.id !== 'string' || value.id.length === 0) return undefined
+  return {
+    id: value.id,
+    ...(typeof value.type === 'string' && value.type.length > 0 ? { type: value.type } : {}),
+    ...(typeof value.name === 'string' && value.name.length > 0 ? { name: value.name } : {}),
+    ...(finite(value.x) === undefined ? {} : { x: finite(value.x) }),
+    ...(finite(value.y) === undefined ? {} : { y: finite(value.y) }),
+    ...(finite(value.width) === undefined ? {} : { width: finite(value.width) }),
+    ...(finite(value.height) === undefined ? {} : { height: finite(value.height) }),
+  }
+}
+
+export function liveSelectionOf(value: unknown): OpenPencilLiveSelection | undefined {
+  if (!isRecord(value) || typeof value.sourcePath !== 'string' || value.sourcePath.length === 0) return undefined
+  return {
+    sourcePath: value.sourcePath,
+    activePageId: typeof value.activePageId === 'string' ? value.activePageId : '',
+    selectedIds: Array.isArray(value.selectedIds)
+      ? value.selectedIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+      : [],
+    nodes: Array.isArray(value.nodes)
+      ? value.nodes.map(nodeOf).filter((node): node is OpenPencilNodeSelection => node !== undefined)
+      : [],
+    updatedAt: finite(value.updatedAt) ?? Date.now(),
+  }
+}
+
+function sameSelection(a: OpenPencilLiveSelection | undefined, b: OpenPencilLiveSelection | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b
+  return a.sourcePath === b.sourcePath
+    && a.activePageId === b.activePageId
+    && JSON.stringify(a.selectedIds) === JSON.stringify(b.selectedIds)
+    && JSON.stringify(a.nodes) === JSON.stringify(b.nodes)
+}
+
+export function publishOpenPencilSelection(sessionId: string, selection: OpenPencilLiveSelection): void {
+  const current = stores.get(sessionId) ?? { revision: 0 }
+  if (sameSelection(current.selection, selection)) return
+  stores.set(sessionId, { revision: current.revision + 1, selection })
+  for (const listener of listeners.get(sessionId) ?? []) listener()
+}
+
+export function clearOpenPencilSelection(sessionId: string, sourcePath?: string): void {
+  const current = stores.get(sessionId)
+  if (current === undefined) return
+  if (current.selection === undefined) return
+  if (sourcePath !== undefined && current.selection.sourcePath !== sourcePath) return
+  stores.set(sessionId, { revision: current.revision + 1 })
+  for (const listener of listeners.get(sessionId) ?? []) listener()
+}
+
+export function subscribeOpenPencilSelection(sessionId: string, listener: () => void): () => void {
+  let scoped = listeners.get(sessionId)
+  if (scoped === undefined) {
+    scoped = new Set()
+    listeners.set(sessionId, scoped)
+  }
+  scoped.add(listener)
+  return () => {
+    scoped?.delete(listener)
+    if (scoped?.size === 0) listeners.delete(sessionId)
+  }
+}
+
+export function getOpenPencilSelectionSnapshot(sessionId: string): OpenPencilSelectionStoreSnapshot {
+  // useSyncExternalStore requires referentially stable snapshots while the
+  // underlying state is unchanged. Returning a new empty object here causes
+  // React to enter an update loop before the first selection poll completes.
+  return stores.get(sessionId) ?? EMPTY_SELECTION_STORE_SNAPSHOT
+}

--- a/src/design-tools.ts
+++ b/src/design-tools.ts
@@ -1,0 +1,241 @@
+/** Model-facing tools that directly drive the active OpenPencil canvas. */
+
+import { defineTool, type JsonValue, type ToolRunContext } from '@deepseek-ai/dsh-tools'
+import type { EditorHostController } from './editor-host.js'
+import { resolveInputFile } from './renderer.js'
+import type { OpenPencilSelectionSnapshot } from './mcp-client.js'
+import {
+  OPENPENCIL_CREATE_TOOL_NAME,
+  OPENPENCIL_EDIT_TOOL_NAME,
+  OPENPENCIL_SELECTION_TOOL_NAME,
+} from './tool-names.js'
+
+const MAX_OPERATIONS_LENGTH = 256 * 1024
+
+function sessionWorkspace(exec: ToolRunContext): string {
+  return exec.agent?.session.header.cwd ?? process.cwd()
+}
+
+async function expectedSource(path: string | undefined, exec: ToolRunContext): Promise<string | undefined> {
+  return path === undefined ? undefined : resolveInputFile(path, sessionWorkspace(exec))
+}
+
+function ownerSessionId(exec: ToolRunContext): string | undefined {
+  return exec.agent === undefined ? undefined : String(exec.agent.id)
+}
+
+const renderJson = (_args: unknown, value: unknown): [{ type: 'text'; text: string }] => [{
+  type: 'text',
+  text: JSON.stringify(value, null, 2),
+}]
+
+const nodeSchema = {
+  type: 'object' as const,
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string' as const, required: true as const },
+    type: { type: 'string' as const },
+    name: { type: 'string' as const },
+    x: { type: 'number' as const },
+    y: { type: 'number' as const },
+    width: { type: 'number' as const },
+    height: { type: 'number' as const },
+  },
+} as const
+
+const selectionProperties = {
+  sourcePath: { type: 'string' as const, required: true as const },
+  activePageId: { type: 'string' as const, required: true as const },
+  selectedIds: { type: 'array' as const, items: { type: 'string' as const }, required: true as const },
+  nodes: { type: 'array' as const, items: nodeSchema, required: true as const },
+  count: { type: 'integer' as const, required: true as const },
+  updatedAt: { type: 'integer' as const, required: true as const },
+} as const
+
+function selectionResult(selection: OpenPencilSelectionSnapshot) {
+  return { ...selection, count: selection.selectedIds.length }
+}
+
+/** Read the exact selection the user currently has on the editable canvas. */
+export function createDesignSelectionTool(editorHost: EditorHostController) {
+  return defineTool({
+    name: OPENPENCIL_SELECTION_TOOL_NAME,
+    description: 'Read the current selection from the live OpenPencil sidebar canvas. '
+      + 'Use this before modifying a node. Returns selected node ids, names, types, bounds, and the active page. '
+      + 'The editable sidebar must already be open. If path is supplied, the tool refuses to target a different canvas.',
+    parameters: {
+      path: { type: 'string', description: 'Optional .op path used to assert which live editor is being read.' },
+    },
+    output: {
+      schema: {
+        type: 'object', additionalProperties: false, properties: selectionProperties,
+      },
+      render: renderJson,
+    },
+    async execute(args: { path?: string }, exec) {
+      const sourcePath = await expectedSource(args.path, exec)
+      const selection = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: ownerSessionId(exec), signal: exec.signal })
+      return selectionResult(selection)
+    },
+    presentCall: () => ({ card: 'generic', title: 'Read OpenPencil selection', kind: 'read' }),
+  })
+}
+
+export interface DesignCreateArgs {
+  path: string
+  operations: string
+  pageId?: string
+  canvasWidth?: number
+  postProcess?: boolean
+}
+
+/** Apply one transactional OpenPencil batch program to generate design nodes. */
+export function createDesignCreateTool(editorHost: EditorHostController) {
+  return defineTool({
+    name: OPENPENCIL_CREATE_TOOL_NAME,
+    description: 'Generate or restructure design nodes directly on the active OpenPencil canvas using one transactional batch_design program. '
+      + 'The editable sidebar must already be open. Use concise newline-separated operations: '
+      + 'I(parentId, nodeJson) inserts, U(nodeId, patchJson) updates, D(nodeId) deletes, '
+      + 'M(nodeId,parentId,index) moves, C(nodeId,parentId,overrides) clones, and R(nodeId,nodeJson) replaces. '
+      + 'All operations apply together or none apply. The canvas updates live but remains unsaved until the sidebar Save action.',
+    parameters: {
+      path: { type: 'string', required: true, description: 'The .op path used to bind this write to the intended live editor.' },
+      operations: {
+        type: 'string', required: true,
+        description: 'Newline-separated batch_design operations, for example I("page-id", {"type":"frame","id":"hero","name":"Hero","x":0,"y":0,"width":1200,"height":800}).',
+      },
+      pageId: { type: 'string', description: 'Optional page id. Defaults to the live editor active page.' },
+      canvasWidth: { type: 'number', description: 'Optional canvas width hint for post-processing.' },
+      postProcess: { type: 'boolean', description: 'Run OpenPencil post-processing after the batch. Default false.' },
+    },
+    output: {
+      schema: {
+        type: 'object', additionalProperties: false,
+        properties: {
+          ...selectionProperties,
+          applied: { type: 'boolean', const: true, required: true },
+          dirty: { type: 'boolean', const: true, required: true },
+          saved: { type: 'boolean', const: false, required: true },
+          result: { type: 'object', additionalProperties: true },
+          note: { type: 'string', required: true },
+        },
+      },
+      render: renderJson,
+    },
+    async execute(args: DesignCreateArgs, exec) {
+      if (args.operations.trim().length === 0) throw new Error(`${OPENPENCIL_CREATE_TOOL_NAME}: operations must not be empty`)
+      if (args.operations.length > MAX_OPERATIONS_LENGTH) throw new Error(`${OPENPENCIL_CREATE_TOOL_NAME}: operations are too large`)
+      const sourcePath = await expectedSource(args.path, exec)
+      const owner = ownerSessionId(exec)
+      const before = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal })
+      const result = await editorHost.callActiveMcp('batch_design', {
+        operations: args.operations,
+        ...(args.pageId !== undefined && args.pageId.length > 0
+          ? { pageId: args.pageId }
+          : before.activePageId === '' ? {} : { pageId: before.activePageId }),
+        ...(args.canvasWidth === undefined ? {} : { canvasWidth: args.canvasWidth }),
+        ...(args.postProcess === undefined ? {} : { postProcess: args.postProcess }),
+      }, { sourcePath, ownerSessionId: owner, signal: exec.signal })
+      const selection = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal })
+      return {
+        ...selectionResult(selection),
+        applied: true as const,
+        dirty: true as const,
+        saved: false as const,
+        ...(typeof result.value === 'object' && result.value !== null && !Array.isArray(result.value)
+          ? { result: result.value as Record<string, JsonValue> }
+          : {}),
+        note: 'Applied to the live OpenPencil canvas. Use Save in the sidebar to persist the .op file.',
+      }
+    },
+    presentCall: () => ({ card: 'generic', title: 'Generate on OpenPencil canvas', kind: 'execute' }),
+  })
+}
+
+export interface DesignEditArgs {
+  path: string
+  nodeId?: string
+  changes: Record<string, JsonValue>
+}
+
+/** Patch one explicit node, or the single node the user selected. */
+export function createDesignEditTool(editorHost: EditorHostController) {
+  return defineTool({
+    name: OPENPENCIL_EDIT_TOOL_NAME,
+    description: 'Modify one node directly on the active OpenPencil canvas. '
+      + 'When nodeId is omitted, this tool targets the single node currently selected by the user; '
+      + 'it refuses an empty or multi-selection instead of guessing. Pass rich OpenPencil node fields in changes, '
+      + 'for example content, name, x, y, width, height, fill, fontSize, padding, layout, or opacity. '
+      + 'The canvas updates live but remains unsaved until the sidebar Save action.',
+    parameters: {
+      path: { type: 'string', required: true, description: 'The .op path used to bind this write to the intended live editor.' },
+      nodeId: { type: 'string', description: 'Explicit target node id. Omit to use the one selected canvas node.' },
+      changes: {
+        type: 'object', additionalProperties: true, required: true,
+        description: 'Shallow OpenPencil node patch. Rich canonical fields are preserved.',
+      },
+    },
+    output: {
+      schema: {
+        type: 'object', additionalProperties: false,
+        properties: {
+          ...selectionProperties,
+          applied: { type: 'boolean', const: true, required: true },
+          dirty: { type: 'boolean', const: true, required: true },
+          saved: { type: 'boolean', const: false, required: true },
+          targetNodeId: { type: 'string', required: true },
+          targetSource: { type: 'string', enum: ['explicit', 'selection'], required: true },
+          result: { type: 'object', additionalProperties: true },
+          note: { type: 'string', required: true },
+        },
+      },
+      render: renderJson,
+    },
+    async execute(args: DesignEditArgs, exec) {
+      if (Object.keys(args.changes).length === 0) throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: changes must not be empty`)
+      const sourcePath = await expectedSource(args.path, exec)
+      const owner = ownerSessionId(exec)
+      const before = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal })
+      const explicit = args.nodeId?.trim()
+      let targetNodeId: string
+      let targetSource: 'explicit' | 'selection'
+      if (explicit !== undefined && explicit.length > 0) {
+        if (!before.selectedIds.includes(explicit)) {
+          throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: nodeId ${explicit} is not in the current canvas selection`)
+        }
+        targetNodeId = explicit
+        targetSource = 'explicit'
+      } else {
+        if (before.selectedIds.length === 0) {
+          throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: no canvas node is selected; select one in OpenPencil or pass nodeId`)
+        }
+        if (before.selectedIds.length !== 1) {
+          throw new Error(`${OPENPENCIL_EDIT_TOOL_NAME}: ${before.selectedIds.length} nodes are selected; pass nodeId to choose one`)
+        }
+        targetNodeId = before.selectedIds[0]!
+        targetSource = 'selection'
+      }
+      const result = await editorHost.callActiveMcp('update_node', {
+        nodeId: targetNodeId,
+        data: args.changes,
+        ...(before.activePageId === '' ? {} : { pageId: before.activePageId }),
+      }, { sourcePath, ownerSessionId: owner, signal: exec.signal })
+      const selection = await editorHost.getActiveSelection({ sourcePath, ownerSessionId: owner, signal: exec.signal })
+      return {
+        ...selectionResult(selection),
+        applied: true as const,
+        dirty: true as const,
+        saved: false as const,
+        targetNodeId,
+        targetSource,
+        ...(typeof result.value === 'object' && result.value !== null && !Array.isArray(result.value)
+          ? { result: result.value as Record<string, JsonValue> }
+          : {}),
+        note: 'Applied to the live OpenPencil canvas. Use Save in the sidebar to persist the .op file.',
+      }
+    },
+    presentCall: (args: DesignEditArgs) => ({
+      card: 'generic', title: args.nodeId === undefined ? 'Edit selected OpenPencil node' : `Edit OpenPencil node ${args.nodeId}`, kind: 'execute',
+    }),
+  })
+}

--- a/src/editor-host.ts
+++ b/src/editor-host.ts
@@ -14,6 +14,14 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { homedir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join, resolve } from 'node:path'
+import {
+  callOpenPencilMcp,
+  getOpenPencilMcpVersion,
+  selectionSnapshotFromMcp,
+  type OpenPencilMcpResult,
+  type OpenPencilSelectionSnapshot,
+} from './mcp-client.js'
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js'
 
 export const EDITOR_ROUTE_PREFIX = '/_dsh/dsh-openpencil/editor'
 
@@ -95,6 +103,7 @@ interface ManagedHandshake {
 interface EditorSession {
   id: string
   sourcePath: string
+  ownerSessionId?: string
   baselineSha256: string
   child: ChildProcessWithoutNullStreams
   iframeUrl: string
@@ -103,6 +112,16 @@ interface EditorSession {
   createdAt: number
   closed: boolean
   saving: boolean
+  mutating: boolean
+}
+
+export type OpenPencilLiveTool = 'get_selection' | 'update_node' | 'batch_design'
+
+export interface ActiveMcpCallOptions {
+  /** Refuse to drive a different transcript card's live editor. */
+  sourcePath?: string
+  ownerSessionId?: string
+  signal?: AbortSignal
 }
 
 function json(res: ServerResponse, status: number, value: unknown): void {
@@ -112,6 +131,20 @@ function json(res: ServerResponse, status: number, value: unknown): void {
   res.setHeader('cache-control', 'no-store')
   res.setHeader('x-content-type-options', 'nosniff')
   res.end(body)
+}
+
+async function waitForResponseFinish(res: ServerResponse): Promise<boolean> {
+  if (res.writableFinished) return true
+  await new Promise<void>(resolveFinished => {
+    const finish = (): void => {
+      res.off('finish', finish)
+      res.off('close', finish)
+      resolveFinished()
+    }
+    res.once('finish', finish)
+    res.once('close', finish)
+  })
+  return res.writableFinished
 }
 
 function errorMessage(error: unknown): string {
@@ -324,14 +357,34 @@ async function waitForEditorReady(baseUrl: string): Promise<void> {
   throw new Error(`OpenPencil editor web bundle was not ready${last === '' ? '' : `: ${last}`}`)
 }
 
-async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
-  if (child.exitCode !== null || child.killed) return
-  child.stdin.end()
-  const closed = await Promise.race([
-    new Promise<boolean>(resolveClosed => child.once('close', () => { resolveClosed(true) })),
-    new Promise<boolean>(resolveTimeout => setTimeout(() => { resolveTimeout(false) }, STOP_TIMEOUT_MS)),
-  ])
-  if (!closed && child.exitCode === null) child.kill('SIGKILL')
+const stoppingChildren = new WeakMap<ChildProcessWithoutNullStreams, Promise<void>>()
+
+function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  const current = stoppingChildren.get(child)
+  if (current !== undefined) return current
+  if (child.exitCode !== null || child.killed) return Promise.resolve()
+  const stopping = (async (): Promise<void> => {
+    if (!child.stdin.writableEnded) child.stdin.end()
+    const closed = await new Promise<boolean>(resolveClosed => {
+      let settled = false
+      const finish = (value: boolean): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        child.off('close', onClose)
+        resolveClosed(value)
+      }
+      const onClose = (): void => { finish(true) }
+      const timer = setTimeout(() => { finish(false) }, STOP_TIMEOUT_MS)
+      child.once('close', onClose)
+    })
+    if (!closed && child.exitCode === null) child.kill('SIGKILL')
+  })()
+  stoppingChildren.set(child, stopping)
+  void stopping.finally(() => {
+    if (stoppingChildren.get(child) === stopping) stoppingChildren.delete(child)
+  })
+  return stopping
 }
 
 async function atomicWriteDocument(path: string, text: string): Promise<string> {
@@ -368,8 +421,11 @@ async function atomicWriteDocument(path: string, text: string): Promise<string> 
 export class EditorHostController {
   readonly binary = findEditorHostBinary()
   #routeRefs = 0
+  #routeGeneration = 0
   readonly #editorKey: Buffer
   #sessions = new Map<string, EditorSession>()
+  #pendingChildren = new Set<ChildProcessWithoutNullStreams>()
+  #launchQueue: Promise<void> = Promise.resolve()
 
   constructor(masterKey: Buffer) {
     this.#editorKey = deriveEditorKey(masterKey)
@@ -417,9 +473,26 @@ export class EditorHostController {
       const refresh = new RegExp(`^${EDITOR_ROUTE_PREFIX}/([A-Za-z0-9_.-]+)/refresh$`).exec(url.pathname)
       const legacyRefresh = url.pathname === `${EDITOR_ROUTE_PREFIX}/refresh`
       const save = new RegExp(`^${EDITOR_ROUTE_PREFIX}/session/([A-Za-z0-9_-]+)/save$`).exec(url.pathname)
+      const selection = new RegExp(`^${EDITOR_ROUTE_PREFIX}/session/([A-Za-z0-9_-]+)/selection$`).exec(url.pathname)
       const close = new RegExp(`^${EDITOR_ROUTE_PREFIX}/session/([A-Za-z0-9_-]+)$`).exec(url.pathname)
       if (launch !== null && req.method === 'POST') {
-        await this.#launch(launch[1]!, requestOrigin(req), res)
+        const body = await readRequestBody(req)
+        let ownerSessionId: string | undefined
+        if (body.length > 0) {
+          try {
+            const value: unknown = JSON.parse(body.toString('utf8'))
+            if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+              const candidate = (value as Record<string, unknown>).sessionId
+              if (typeof candidate === 'string' && candidate.length > 0 && candidate.length <= 256) ownerSessionId = candidate
+            }
+          } catch {
+            throw new HttpError(400, 'editor launch request is not valid JSON')
+          }
+        }
+        const routeGeneration = this.#routeGeneration
+        await this.#serializeLaunch(() => this.#launch(
+          launch[1]!, requestOrigin(req), res, routeGeneration, ownerSessionId,
+        ))
         return
       }
       if (refresh !== null && req.method === 'POST') {
@@ -431,11 +504,16 @@ export class EditorHostController {
       if (legacyRefresh && req.method === 'POST') {
         requestOrigin(req)
         await readRequestBody(req).catch(() => Buffer.alloc(0))
-        throw new HttpError(410, 'This editor card predates restart-safe editing; rerun design_render once')
+        throw new HttpError(410, `This editor card predates restart-safe editing; rerun ${OPENPENCIL_RENDER_TOOL_NAME} once`)
       }
       if (save !== null && req.method === 'POST') {
         requestOrigin(req)
         await this.#save(save[1]!, req, res)
+        return
+      }
+      if (selection !== null && req.method === 'GET') {
+        const snapshot = await this.#selectionForSession(selection[1]!)
+        json(res, 200, { ok: true, selection: snapshot })
         return
       }
       if (close !== null && req.method === 'DELETE') {
@@ -453,87 +531,206 @@ export class EditorHostController {
   }
 
   async dispose(): Promise<void> {
+    // Invalidate work accepted by the route before it was detached. Pending
+    // launches check this generation around every asynchronous startup phase,
+    // and their child is stopped here so a handshake wait cannot leak.
+    this.#routeGeneration += 1
     const sessions = [...this.#sessions.values()]
     this.#sessions.clear()
-    await Promise.all(sessions.map(session => this.#disposeSession(session)))
+    const pending = [...this.#pendingChildren]
+    await Promise.all([
+      ...sessions.map(session => this.#disposeSession(session)),
+      ...pending.map(child => stopChild(child)),
+    ])
   }
 
-  async #launch(token: string, origin: string, res: ServerResponse): Promise<void> {
-    const capability = this.#openCapability(token)
-    if (Date.now() > capability.launchExpiresAt) throw new HttpError(410, 'editor capability expired; rerun design_render')
-    const current = await readSourceDocument(capability.sourcePath)
-    if (sha256(current) !== capability.sourceSha256) {
-      throw new HttpError(409, 'source changed since this preview; rerun design_render before editing')
-    }
-    const binary = this.binary
-    if (binary === undefined) throw new HttpError(503, 'OpenPencil editor host binary is unavailable')
+  /** Current live editor selection, suitable for Agent context and UI chips. */
+  async getActiveSelection(options: ActiveMcpCallOptions = {}): Promise<OpenPencilSelectionSnapshot> {
+    const session = this.#activeSession(options.sourcePath, options.ownerSessionId)
+    return this.#selectionFor(session, options.signal)
+  }
 
-    // The details panel hosts one editor. Retire an earlier daemon before a
-    // successor starts so stale transcript cards cannot retain authority.
-    const old = [...this.#sessions.values()]
-    this.#sessions.clear()
-    await Promise.all(old.map(session => this.#disposeSession(session)))
-
-    const env: NodeJS.ProcessEnv = { ...process.env }
-    const sourceRoot = sourceRootForBinary(binary)
-    if (sourceRoot !== undefined) {
-      env.OPENPENCIL_WEB_BUNDLE_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'pkg')
-      env.OPENPENCIL_CANVASKIT_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'assets', 'canvaskit')
+  /**
+   * Drive one allowlisted first-party MCP tool on the currently visible
+   * editor. The managed daemon token never crosses this controller boundary.
+   */
+  async callActiveMcp(
+    tool: OpenPencilLiveTool,
+    args: Record<string, unknown>,
+    options: ActiveMcpCallOptions = {},
+  ): Promise<OpenPencilMcpResult> {
+    const session = this.#activeSession(options.sourcePath, options.ownerSessionId)
+    const mutating = tool === 'update_node' || tool === 'batch_design'
+    if ('filePath' in args || 'sourceFilePath' in args || 'source_file_path' in args) {
+      throw new Error('OpenPencil live tools cannot target a filesystem path through MCP arguments')
     }
-    const child = spawn(binary, [
-      '--serve-web', '--managed', '--port', '0', '--file', capability.sourcePath,
-      '--allow-origin', origin,
-    ], { stdio: ['pipe', 'pipe', 'pipe'], env })
-    let diagnostics = ''
-    child.stderr.on('data', (chunk: Buffer) => {
-      if (diagnostics.length < MAX_DIAGNOSTIC_BYTES) {
-        diagnostics += chunk.toString('utf8').slice(0, MAX_DIAGNOSTIC_BYTES - diagnostics.length)
-      }
-    })
-    let handshake: ManagedHandshake
+    if (mutating && (session.saving || session.mutating)) {
+      throw new Error('OpenPencil editor is already applying or saving another change')
+    }
+    if (mutating) session.mutating = true
     try {
-      handshake = await waitForHandshake(child, () => diagnostics.trim())
-      const baseUrl = `http://127.0.0.1:${handshake.port}`
-      await waitForEditorReady(baseUrl)
-      const id = randomBytes(24).toString('base64url')
-      const session: EditorSession = {
-        id,
-        sourcePath: capability.sourcePath,
-        baselineSha256: capability.sourceSha256,
-        child,
-        iframeUrl: `${baseUrl}/?embed=vscode`,
-        daemonToken: handshake.token,
-        refreshExpiresAt: capability.refreshExpiresAt,
-        createdAt: Date.now(),
-        closed: false,
-        saving: false,
+      let beforeVersion: number | undefined
+      if (mutating) {
+        const current = await readSourceDocument(session.sourcePath)
+        if (sha256(current) !== session.baselineSha256) {
+          throw new Error('OpenPencil source changed outside the active editor; rerender before applying Agent changes')
+        }
+        beforeVersion = await getOpenPencilMcpVersion({
+          baseUrl: new URL(session.iframeUrl).origin,
+          token: session.daemonToken,
+          signal: options.signal,
+        })
       }
-      this.#sessions.set(id, session)
-      child.once('close', () => {
-        if (this.#sessions.get(id) === session) this.#sessions.delete(id)
-        session.closed = true
-      })
-      json(res, 200, {
-        sessionId: id,
-        iframeUrl: session.iframeUrl,
+      const result = await callOpenPencilMcp({
+        baseUrl: new URL(session.iframeUrl).origin,
         token: session.daemonToken,
-        saveUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}/save`,
-        closeUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}`,
-        docJson: current.toString('utf8'),
+        tool,
+        arguments: args,
+        signal: options.signal,
       })
-    } catch (error) {
-      await stopChild(child)
-      throw error
+      if (beforeVersion !== undefined) {
+        const afterVersion = await getOpenPencilMcpVersion({
+          baseUrl: new URL(session.iframeUrl).origin,
+          token: session.daemonToken,
+          signal: options.signal,
+        })
+        if (afterVersion <= beforeVersion) {
+          throw new Error(`OpenPencil MCP ${tool} reported success but did not apply a document change`)
+        }
+      }
+      session.createdAt = Date.now()
+      return result
+    } finally {
+      if (mutating) session.mutating = false
+    }
+  }
+
+  async #serializeLaunch(task: () => Promise<void>): Promise<void> {
+    const run = this.#launchQueue.then(task, task)
+    // A failed launch must not poison the lifecycle queue for later requests.
+    this.#launchQueue = run.catch(() => {})
+    await run
+  }
+
+  #assertLaunchLifecycle(routeGeneration: number): void {
+    if (routeGeneration !== this.#routeGeneration || !this.routeAvailable) {
+      throw new HttpError(410, 'editor route was unloaded during launch')
+    }
+  }
+
+  async #launch(
+    token: string,
+    origin: string,
+    res: ServerResponse,
+    routeGeneration: number,
+    ownerSessionId?: string,
+  ): Promise<void> {
+    let disconnected = res.destroyed
+    let launchChild: ChildProcessWithoutNullStreams | undefined
+    const onResponseClose = (): void => {
+      if (res.writableFinished) return
+      disconnected = true
+      if (launchChild !== undefined) void stopChild(launchChild)
+    }
+    res.once('close', onResponseClose)
+    const assertConnected = (): void => {
+      this.#assertLaunchLifecycle(routeGeneration)
+      if (disconnected || res.destroyed) throw new HttpError(499, 'editor launch client disconnected')
+    }
+    try {
+      assertConnected()
+      const capability = this.#openCapability(token)
+      if (Date.now() > capability.launchExpiresAt) throw new HttpError(410, `editor capability expired; rerun ${OPENPENCIL_RENDER_TOOL_NAME}`)
+      const current = await readSourceDocument(capability.sourcePath)
+      assertConnected()
+      if (sha256(current) !== capability.sourceSha256) {
+        throw new HttpError(409, `source changed since this preview; rerun ${OPENPENCIL_RENDER_TOOL_NAME} before editing`)
+      }
+      const binary = this.binary
+      if (binary === undefined) throw new HttpError(503, 'OpenPencil editor host binary is unavailable')
+
+      // The details panel hosts one editor. Retire an earlier daemon before a
+      // successor starts so stale transcript cards cannot retain authority.
+      const old = [...this.#sessions.values()]
+      this.#sessions.clear()
+      await Promise.all(old.map(session => this.#disposeSession(session)))
+      assertConnected()
+
+      const env: NodeJS.ProcessEnv = { ...process.env }
+      const sourceRoot = sourceRootForBinary(binary)
+      if (sourceRoot !== undefined) {
+        env.OPENPENCIL_WEB_BUNDLE_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'pkg')
+        env.OPENPENCIL_CANVASKIT_DIR ??= join(sourceRoot, 'crates', 'op-host-web', 'assets', 'canvaskit')
+      }
+      const child = spawn(binary, [
+        '--serve-web', '--managed', '--port', '0', '--file', capability.sourcePath,
+        '--allow-origin', origin,
+      ], { stdio: ['pipe', 'pipe', 'pipe'], env })
+      launchChild = child
+      this.#pendingChildren.add(child)
+      let diagnostics = ''
+      child.stderr.on('data', (chunk: Buffer) => {
+        if (diagnostics.length < MAX_DIAGNOSTIC_BYTES) {
+          diagnostics += chunk.toString('utf8').slice(0, MAX_DIAGNOSTIC_BYTES - diagnostics.length)
+        }
+      })
+      try {
+        const handshake = await waitForHandshake(child, () => diagnostics.trim())
+        assertConnected()
+        const baseUrl = `http://127.0.0.1:${handshake.port}`
+        await waitForEditorReady(baseUrl)
+        assertConnected()
+        const id = randomBytes(24).toString('base64url')
+        const session: EditorSession = {
+          id,
+          sourcePath: capability.sourcePath,
+          ...(ownerSessionId === undefined ? {} : { ownerSessionId }),
+          baselineSha256: capability.sourceSha256,
+          child,
+          iframeUrl: `${baseUrl}/?embed=vscode`,
+          daemonToken: handshake.token,
+          refreshExpiresAt: capability.refreshExpiresAt,
+          createdAt: Date.now(),
+          closed: false,
+          saving: false,
+          mutating: false,
+        }
+        this.#sessions.set(id, session)
+        this.#pendingChildren.delete(child)
+        child.once('close', () => {
+          if (this.#sessions.get(id) === session) this.#sessions.delete(id)
+          session.closed = true
+        })
+        json(res, 200, {
+          sessionId: id,
+          iframeUrl: session.iframeUrl,
+          token: session.daemonToken,
+          saveUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}/save`,
+          selectionUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}/selection`,
+          closeUrl: `${EDITOR_ROUTE_PREFIX}/session/${id}`,
+          docJson: current.toString('utf8'),
+        })
+        if (!await waitForResponseFinish(res)) {
+          throw new HttpError(499, 'editor launch client disconnected')
+        }
+        launchChild = undefined
+      } catch (error) {
+        this.#pendingChildren.delete(child)
+        await stopChild(child)
+        throw error
+      }
+    } finally {
+      res.off('close', onResponseClose)
     }
   }
 
   async #refresh(token: string, res: ServerResponse): Promise<void> {
     const capability = this.#openCapability(token)
     const now = Date.now()
-    if (now > capability.refreshExpiresAt) throw new HttpError(410, 'editor capability expired; rerun design_render')
+    if (now > capability.refreshExpiresAt) throw new HttpError(410, `editor capability expired; rerun ${OPENPENCIL_RENDER_TOOL_NAME}`)
     const current = await readSourceDocument(capability.sourcePath)
     if (sha256(current) !== capability.sourceSha256) {
-      throw new HttpError(409, 'source changed since this preview; rerun design_render before editing')
+      throw new HttpError(409, `source changed since this preview; rerun ${OPENPENCIL_RENDER_TOOL_NAME} before editing`)
     }
     const next = this.#sealCapability({
       ...capability,
@@ -547,7 +744,7 @@ export class EditorHostController {
     if (!TOKEN_PATTERN.test(id)) throw new HttpError(404, 'editor session not found')
     const session = this.#sessions.get(id)
     if (session === undefined || session.closed) throw new HttpError(410, 'editor session has ended')
-    if (session.saving) throw new HttpError(409, 'another editor save is already in progress')
+    if (session.saving || session.mutating) throw new HttpError(409, 'another editor change or save is already in progress')
     session.saving = true
     try {
       const bytes = await readRequestBody(req)
@@ -606,6 +803,41 @@ export class EditorHostController {
     await this.#disposeSession(session)
   }
 
+  #activeSession(expectedSourcePath?: string, ownerSessionId?: string): EditorSession {
+    this.#prune()
+    const sessions = [...this.#sessions.values()].filter(session => !session.closed)
+    if (sessions.length !== 1) {
+      throw new Error('No active OpenPencil editor. Render with editable=true and open “Edit in sidebar” first.')
+    }
+    const session = sessions[0]!
+    if (ownerSessionId !== undefined && session.ownerSessionId !== ownerSessionId) {
+      throw new Error('The active OpenPencil editor belongs to a different DSH session')
+    }
+    if (expectedSourcePath !== undefined && resolve(expectedSourcePath) !== session.sourcePath) {
+      throw new Error(`The active OpenPencil editor is ${session.sourcePath}, not ${resolve(expectedSourcePath)}`)
+    }
+    return session
+  }
+
+  async #selectionForSession(id: string): Promise<OpenPencilSelectionSnapshot> {
+    if (!TOKEN_PATTERN.test(id)) throw new HttpError(404, 'editor session not found')
+    const session = this.#sessions.get(id)
+    if (session === undefined || session.closed) throw new HttpError(410, 'editor session has ended')
+    return this.#selectionFor(session)
+  }
+
+  async #selectionFor(session: EditorSession, signal?: AbortSignal): Promise<OpenPencilSelectionSnapshot> {
+    const result = await callOpenPencilMcp({
+      baseUrl: new URL(session.iframeUrl).origin,
+      token: session.daemonToken,
+      tool: 'get_selection',
+      arguments: { readDepth: 0 },
+      signal,
+    })
+    session.createdAt = Date.now()
+    return selectionSnapshotFromMcp(session.sourcePath, result.value)
+  }
+
   async #disposeSession(session: EditorSession): Promise<void> {
     if (session.closed) return
     session.closed = true
@@ -634,7 +866,7 @@ export class EditorHostController {
     if (!token.startsWith(EDITOR_CAPABILITY_PREFIX)) {
       // Compatibility boundary for pre-fix transcript cards: their random
       // in-memory token cannot safely be recreated after a plugin reload.
-      throw new HttpError(410, 'editor capability expired; rerun design_render')
+      throw new HttpError(410, `editor capability expired; rerun ${OPENPENCIL_RENDER_TOOL_NAME}`)
     }
     if (token.length > EDITOR_CAPABILITY_MAX_LENGTH) throw new HttpError(404, 'editor capability not found')
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
  * registered through `ctx.effect` (or a returned disposer) so unloading the
  * plugin removes every contribution.
  *
- * The `design_render` tool never returns an ImageBlock — the DeepSeek
+ * The `openpencil_render` tool never returns an ImageBlock — the DeepSeek
  * adapter rejects image blocks anywhere in a request. The browser-only
  * envelope rides `output.presentationMeta` into `ToolCallBlock.meta`, and
  * the keyed `tool.call.toolview` client component renders a PNG-first card
@@ -25,6 +25,11 @@ import {
 } from './renderer.js'
 import { createDesignRenderTool } from './tool.js'
 import {
+  createDesignCreateTool,
+  createDesignEditTool,
+  createDesignSelectionTool,
+} from './design-tools.js'
+import {
   VIEWER_ASSET_ROUTE_PREFIX,
   prepareViewerAssets,
 } from './viewer-assets.js'
@@ -32,6 +37,22 @@ import {
   EDITOR_ROUTE_PREFIX,
   EditorHostController,
 } from './editor-host.js'
+import {
+  OPENPENCIL_CREATE_TOOL_NAME,
+  OPENPENCIL_EDIT_TOOL_NAME,
+  OPENPENCIL_RENDER_TOOL_NAME,
+  OPENPENCIL_SELECTION_TOOL_NAME,
+  OPENPENCIL_TOOL_NAMES,
+} from './tool-names.js'
+
+export {
+  LEGACY_DESIGN_RENDER_TOOL_NAME,
+  OPENPENCIL_CREATE_TOOL_NAME,
+  OPENPENCIL_EDIT_TOOL_NAME,
+  OPENPENCIL_RENDER_TOOL_NAME,
+  OPENPENCIL_SELECTION_TOOL_NAME,
+  OPENPENCIL_TOOL_NAMES,
+} from './tool-names.js'
 
 /** Stable plugin name (the loader entry id in cordis.patch.yml). */
 export const name = '@dsh-external/dsh-openpencil'
@@ -52,16 +73,28 @@ export async function apply(ctx: Context): Promise<() => void> {
   // without the webserver still gets a plain-JSON result — no dangling URL.
   disposers.push(ctx.effect(
     () => ctx.tools.register(createDesignRenderTool(controller, viewerAssets, editorHost)),
-    'dsh-openpencil: design_render tool',
+    `dsh-openpencil: ${OPENPENCIL_RENDER_TOOL_NAME} tool`,
+  ))
+  disposers.push(ctx.effect(
+    () => ctx.tools.register(createDesignSelectionTool(editorHost)),
+    `dsh-openpencil: ${OPENPENCIL_SELECTION_TOOL_NAME} tool`,
+  ))
+  disposers.push(ctx.effect(
+    () => ctx.tools.register(createDesignCreateTool(editorHost)),
+    `dsh-openpencil: ${OPENPENCIL_CREATE_TOOL_NAME} tool`,
+  ))
+  disposers.push(ctx.effect(
+    () => ctx.tools.register(createDesignEditTool(editorHost)),
+    `dsh-openpencil: ${OPENPENCIL_EDIT_TOOL_NAME} tool`,
   ))
 
-  // Optional Web routes: only mounted when an httpServer service exists
+  // Optional Web routes: only mounted when a webServer service exists
   // (headless profiles never attach, and `routeAvailable` stays false).
   // The inject fiber is parent-scoped and tears itself down with this ctx;
   // the inner effect's disposer is the route removal.
-  ctx.inject(['httpServer'], (webCtx) => webCtx.effect(() => {
+  ctx.inject(['webServer'], (webCtx) => webCtx.effect(() => {
     const detach = controller.attachRoute()
-    const disposeRoute = webCtx.httpServer.register({
+    const disposeRoute = webCtx.webServer.register({
       kind: 'prefix',
       path: RENDER_ROUTE_PREFIX,
       handler: (req, res) => controller.handle(req, res),
@@ -69,7 +102,7 @@ export async function apply(ctx: Context): Promise<() => void> {
     const disposeViewerRoute = viewerAssets.available
       ? (() => {
           const detachViewer = viewerAssets.attachRoute()
-          const disposeViewer = webCtx.httpServer.register({
+          const disposeViewer = webCtx.webServer.register({
             kind: 'prefix',
             path: VIEWER_ASSET_ROUTE_PREFIX,
             handler: (req, res) => viewerAssets.handle(req, res),
@@ -81,7 +114,7 @@ export async function apply(ctx: Context): Promise<() => void> {
         })()
       : undefined
     const detachEditor = editorHost.attachRoute()
-    const disposeEditorRoute = webCtx.httpServer.register({
+    const disposeEditorRoute = webCtx.webServer.register({
       kind: 'prefix',
       path: EDITOR_ROUTE_PREFIX,
       handler: (req, res) => editorHost.handle(req, res),
@@ -96,7 +129,7 @@ export async function apply(ctx: Context): Promise<() => void> {
     }
   }, 'dsh-openpencil: render route'))
 
-  ctx.logger.info(`dsh-openpencil mounted (design_render + gallery + render route; viewer assets: ${viewerAssets.available ? 'ready' : 'unavailable'}; editor: ${editorHost.available ? 'ready' : 'unavailable'})`)
+  ctx.logger.info(`dsh-openpencil mounted (${OPENPENCIL_TOOL_NAMES.join(' + ')}; viewer assets: ${viewerAssets.available ? 'ready' : 'unavailable'}; editor: ${editorHost.available ? 'ready' : 'unavailable'})`)
   return () => {
     for (const dispose of disposers.reverse()) dispose()
     void editorHost.dispose()

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -1,0 +1,189 @@
+/** Strict loopback JSON-RPC client for one managed OpenPencil editor. */
+
+const MCP_TIMEOUT_MS = 20_000
+const MAX_MCP_RESPONSE_BYTES = 2 * 1024 * 1024
+
+export interface OpenPencilNodeSummary {
+  id: string
+  type?: string
+  name?: string
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+}
+
+export interface OpenPencilSelectionSnapshot {
+  sourcePath: string
+  activePageId: string
+  selectedIds: string[]
+  nodes: OpenPencilNodeSummary[]
+  updatedAt: number
+}
+
+export interface OpenPencilMcpResult {
+  tool: string
+  value: unknown
+  text: string
+}
+
+interface McpCallOptions {
+  baseUrl: string
+  token: string
+  tool: string
+  arguments?: Record<string, unknown>
+  signal?: AbortSignal
+  fetcher?: typeof fetch
+}
+
+interface McpVersionOptions {
+  baseUrl: string
+  token: string
+  signal?: AbortSignal
+  fetcher?: typeof fetch
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function finite(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function textFromContent(value: unknown): string {
+  if (!Array.isArray(value)) return ''
+  const parts: string[] = []
+  for (const item of value) {
+    if (isRecord(item) && item.type === 'text' && typeof item.text === 'string') parts.push(item.text)
+  }
+  return parts.join('\n')
+}
+
+/** Decode a JSON-RPC tools/call envelope, including MCP's HTTP-200 errors. */
+export function parseOpenPencilMcpResponse(tool: string, value: unknown): OpenPencilMcpResult {
+  if (!isRecord(value)) throw new Error(`OpenPencil MCP ${tool} returned an invalid JSON-RPC response`)
+  if (isRecord(value.error)) {
+    const message = optionalString(value.error.message) ?? JSON.stringify(value.error)
+    throw new Error(`OpenPencil MCP ${tool} failed: ${message}`)
+  }
+  if (!isRecord(value.result)) throw new Error(`OpenPencil MCP ${tool} omitted its result`)
+  const text = textFromContent(value.result.content)
+  if (value.result.isError === true) {
+    throw new Error(`OpenPencil MCP ${tool} failed${text === '' ? '' : `: ${text}`}`)
+  }
+  let decoded: unknown = text
+  if (text !== '') {
+    try {
+      decoded = JSON.parse(text)
+    } catch {
+      // Some first-party tools intentionally return human-readable text.
+    }
+  }
+  if (isRecord(decoded) && decoded.applied === false) {
+    const details = Array.isArray(decoded.errors)
+      ? decoded.errors.map(error => typeof error === 'string' ? error : JSON.stringify(error)).join('; ')
+      : text
+    throw new Error(`OpenPencil MCP ${tool} did not apply${details === '' ? '' : `: ${details}`}`)
+  }
+  return { tool, value: decoded, text }
+}
+
+/** Call a first-party tool on a managed editor without exposing its daemon token. */
+export async function callOpenPencilMcp(options: McpCallOptions): Promise<OpenPencilMcpResult> {
+  const origin = new URL(options.baseUrl)
+  const loopback = origin.hostname === '127.0.0.1' || origin.hostname === 'localhost' || origin.hostname === '::1'
+  if (!loopback || (origin.protocol !== 'http:' && origin.protocol !== 'https:')) {
+    throw new Error('OpenPencil MCP endpoint must use an HTTP loopback origin')
+  }
+  if (origin.pathname !== '/' || origin.search !== '' || origin.hash !== '') {
+    throw new Error('OpenPencil MCP base URL must be an origin')
+  }
+  const fetcher = options.fetcher ?? fetch
+  const timeout = AbortSignal.timeout(MCP_TIMEOUT_MS)
+  const signal = options.signal === undefined ? timeout : AbortSignal.any([options.signal, timeout])
+  const response = await fetcher(new URL('/mcp', origin).href, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${options.token}`,
+      'x-openpencil-token': options.token,
+      'content-type': 'application/json',
+      accept: 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: `dsh-${Date.now().toString(36)}`,
+      method: 'tools/call',
+      params: { name: options.tool, arguments: options.arguments ?? {} },
+    }),
+    signal,
+  })
+  const bytes = Buffer.from(await response.arrayBuffer())
+  if (bytes.length > MAX_MCP_RESPONSE_BYTES) throw new Error(`OpenPencil MCP ${options.tool} response is too large`)
+  if (!response.ok) throw new Error(`OpenPencil MCP ${options.tool} request failed (${response.status})`)
+  let value: unknown
+  try {
+    value = JSON.parse(bytes.toString('utf8'))
+  } catch {
+    throw new Error(`OpenPencil MCP ${options.tool} returned invalid JSON`)
+  }
+  return parseOpenPencilMcpResponse(options.tool, value)
+}
+
+/** Probe the daemon document version before and after a write. */
+export async function getOpenPencilMcpVersion(options: McpVersionOptions): Promise<number> {
+  const origin = new URL(options.baseUrl)
+  const loopback = origin.hostname === '127.0.0.1' || origin.hostname === 'localhost' || origin.hostname === '::1'
+  if (!loopback || (origin.protocol !== 'http:' && origin.protocol !== 'https:')) {
+    throw new Error('OpenPencil MCP endpoint must use an HTTP loopback origin')
+  }
+  const response = await (options.fetcher ?? fetch)(new URL('/api/mcp/version', origin).href, {
+    headers: { authorization: `Bearer ${options.token}`, 'x-openpencil-token': options.token },
+    signal: options.signal,
+  })
+  if (!response.ok) throw new Error(`OpenPencil MCP version probe failed (${response.status})`)
+  const value: unknown = await response.json()
+  if (!isRecord(value) || typeof value.version !== 'number' || !Number.isSafeInteger(value.version) || value.version < 0) {
+    throw new Error('OpenPencil MCP version probe returned an invalid result')
+  }
+  return value.version
+}
+
+function nodeSummary(value: unknown): OpenPencilNodeSummary | undefined {
+  if (!isRecord(value) || typeof value.id !== 'string' || value.id.length === 0) return undefined
+  return {
+    id: value.id,
+    ...(optionalString(value.type) === undefined ? {} : { type: optionalString(value.type) }),
+    ...(optionalString(value.name) === undefined ? {} : { name: optionalString(value.name) }),
+    ...(finite(value.x) === undefined ? {} : { x: finite(value.x) }),
+    ...(finite(value.y) === undefined ? {} : { y: finite(value.y) }),
+    ...(finite(value.width) === undefined ? {} : { width: finite(value.width) }),
+    ...(finite(value.height) === undefined ? {} : { height: finite(value.height) }),
+  }
+}
+
+/** Project get_selection into the bounded shape shared with the DSH client. */
+export function selectionSnapshotFromMcp(
+  sourcePath: string,
+  value: unknown,
+  updatedAt = Date.now(),
+): OpenPencilSelectionSnapshot {
+  if (!isRecord(value)) throw new Error('OpenPencil get_selection returned an invalid result')
+  const selectedIds = Array.isArray(value.selectedIds)
+    ? value.selectedIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    : []
+  const nodes = Array.isArray(value.nodes)
+    ? value.nodes.map(nodeSummary).filter((node): node is OpenPencilNodeSummary => node !== undefined)
+    : []
+  return {
+    sourcePath,
+    activePageId: optionalString(value.activePageId) ?? '',
+    selectedIds,
+    nodes,
+    updatedAt,
+  }
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,7 +1,7 @@
 /**
  * Offscreen rendering + signed HTTP delivery for `.op` documents.
  *
- * `design_render` snapshots the source document, uses OpenPencil's own
+ * `openpencil_render` snapshots the source document, uses OpenPencil's own
  * headless exporter for design-fidelity PNG output, retaining every
  * top-level frame for the conversation gallery, and only invokes Jian
  * as an explicitly disclosed runtime-preview fallback when the exact binary
@@ -27,6 +27,7 @@ import { randomUUID } from 'node:crypto'
 import type { JsonValue } from '@deepseek-ai/dsh-tools'
 import type { ViewerGrant } from './viewer-assets.js'
 import type { EditorGrant } from './editor-host.js'
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js'
 
 /** HTTP prefix owned by the render capability route. */
 export const RENDER_ROUTE_PREFIX = '/_dsh/dsh-openpencil/render'
@@ -117,7 +118,7 @@ export interface RenderResult {
   mimeType: 'image/png'
   kind: 'image'
   description: string
-  sourceTool: 'design_render'
+  sourceTool: typeof OPENPENCIL_RENDER_TOOL_NAME
   previewIntent: 'image'
   bytes: number
   width?: number
@@ -466,7 +467,7 @@ export function expandUserHome(raw: string): string {
  */
 export async function resolveInputFile(raw: string, cwd: string): Promise<string> {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
-    throw new Error('design_render: path is required')
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: path is required`)
   }
   const expanded = expandUserHome(raw.trim())
   const target = isAbsolute(expanded) ? expanded : resolve(cwd, expanded)
@@ -474,13 +475,13 @@ export async function resolveInputFile(raw: string, cwd: string): Promise<string
   try {
     real = await realpath(target)
   } catch {
-    throw new Error(`design_render: .op file not found: ${raw}`)
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: .op file not found: ${raw}`)
   }
   const info = await stat(real)
-  if (!info.isFile()) throw new Error(`design_render: not a regular file: ${raw}`)
+  if (!info.isFile()) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: not a regular file: ${raw}`)
   const extension = real.slice(real.lastIndexOf('.')).toLowerCase()
   if (extension !== '.op') {
-    throw new Error(`design_render: expected a .op file (got "${extension || '(none)'}")`)
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: expected a .op file (got "${extension || '(none)'}")`)
   }
   return real
 }
@@ -488,9 +489,9 @@ export async function resolveInputFile(raw: string, cwd: string): Promise<string
 /** Freeze source bytes before rendering so preview and web viewer cannot diverge. */
 export async function createDocumentSnapshot(input: string): Promise<DocumentSnapshot> {
   const bytes = await readFile(input)
-  if (bytes.length === 0) throw new Error('design_render: source document is empty')
+  if (bytes.length === 0) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: source document is empty`)
   if (bytes.length > MAX_DOCUMENT_BYTES) {
-    throw new Error(`design_render: source document exceeds ${MAX_DOCUMENT_BYTES} bytes`)
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: source document exceeds ${MAX_DOCUMENT_BYTES} bytes`)
   }
   const sha256 = createHash('sha256').update(bytes).digest('hex')
   const filename = `${sha256}.op`
@@ -502,7 +503,7 @@ export async function createDocumentSnapshot(input: string): Promise<DocumentSna
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
     const existing = await readFile(path)
     if (existing.length !== bytes.length || createHash('sha256').update(existing).digest('hex') !== sha256) {
-      throw new Error('design_render: content-addressed snapshot was modified')
+      throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: content-addressed snapshot was modified`)
     }
   }
   return { path, filename, mimeType: 'application/json', bytes: bytes.length, sha256 }
@@ -681,7 +682,7 @@ export async function runOpenPencilRender(options: {
 }> {
   const scale = options.scale ?? 1
   if (!Number.isFinite(scale) || scale <= 0 || scale > 8) {
-    throw new Error('design_render: scale must be a finite number greater than 0 and at most 8')
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: scale must be a finite number greater than 0 and at most 8`)
   }
   await mkdir(stateRoot(), { recursive: true, mode: 0o700 })
   const tempRoot = await mkdtemp(join(stateRoot(), 'exact-'))
@@ -714,8 +715,8 @@ export async function runOpenPencilRender(options: {
     })
     const stdout = Buffer.concat(stdoutChunks).toString('utf8')
     const stderr = Buffer.concat(stderrChunks).toString('utf8')
-    if (options.signal.aborted) throw new Error('design_render: OpenPencil render was cancelled')
-    if (timedOut) throw new Error(`design_render: OpenPencil render timed out after ${RENDER_TIMEOUT_MS} ms`)
+    if (options.signal.aborted) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: OpenPencil render was cancelled`)
+    if (timedOut) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: OpenPencil render timed out after ${RENDER_TIMEOUT_MS} ms`)
     if (code !== 0) throw new Error(`OpenPencil render exited with ${String(code)}${stderr.trim() === '' ? '' : `: ${stderr.trim()}`}`)
     const discoveredPngs = (await readdir(outDir)).filter(name => name.toLowerCase().endsWith('.png'))
     const sourceFrames = await sourceFrameDescriptors(options.input)
@@ -738,7 +739,7 @@ export async function runOpenPencilRender(options: {
         .filter(name => !sourceOrderedPngs.includes(name) && !writtenPngs.includes(name))
         .sort(),
     ])]
-    if (pngs.length === 0) throw new Error('design_render: OpenPencil produced no PNG')
+    if (pngs.length === 0) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: OpenPencil produced no PNG`)
     const sourceFrameByPng = new Map(sourceFrames.map(frame => [rendererFilename(frame.id), frame]))
     const frames: Array<{ png: string; id?: string; name?: string; index: number }> = []
     try {
@@ -856,21 +857,21 @@ export async function verifyRenderOutput(out: string): Promise<{
   sha256: string
 }> {
   const info = await lstat(out)
-  if (info.isSymbolicLink() || !info.isFile()) throw new Error('design_render: renderer did not produce a regular file')
-  if (info.size > MAX_RENDER_BYTES) throw new Error(`design_render: rendered PNG exceeds ${MAX_RENDER_BYTES} bytes`)
-  if (info.size < 33) throw new Error('design_render: rendered PNG is truncated')
+  if (info.isSymbolicLink() || !info.isFile()) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: renderer did not produce a regular file`)
+  if (info.size > MAX_RENDER_BYTES) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG exceeds ${MAX_RENDER_BYTES} bytes`)
+  if (info.size < 33) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG is truncated`)
   const bytes = await readFile(out)
   const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
-  if (!bytes.subarray(0, 8).equals(signature)) throw new Error('design_render: renderer output is not a PNG')
+  if (!bytes.subarray(0, 8).equals(signature)) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: renderer output is not a PNG`)
   if (bytes.readUInt32BE(8) !== 13 || bytes.toString('ascii', 12, 16) !== 'IHDR') {
-    throw new Error('design_render: PNG has no valid IHDR')
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: PNG has no valid IHDR`)
   }
   const width = bytes.readUInt32BE(16)
   const height = bytes.readUInt32BE(20)
   if (width === 0 || height === 0 || width > MAX_RENDER_DIMENSION || height > MAX_RENDER_DIMENSION) {
-    throw new Error('design_render: rendered PNG dimensions are invalid')
+    throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG dimensions are invalid`)
   }
-  if (width * height > MAX_RENDER_PIXELS) throw new Error('design_render: rendered PNG has too many pixels')
+  if (width * height > MAX_RENDER_PIXELS) throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: rendered PNG has too many pixels`)
   return {
     bytes: info.size,
     width,

--- a/src/tool-names.ts
+++ b/src/tool-names.ts
@@ -1,0 +1,19 @@
+/** Canonical model-facing OpenPencil tool names. */
+export const OPENPENCIL_RENDER_TOOL_NAME = 'openpencil_render' as const
+export const OPENPENCIL_SELECTION_TOOL_NAME = 'openpencil_selection' as const
+export const OPENPENCIL_CREATE_TOOL_NAME = 'openpencil_create' as const
+export const OPENPENCIL_EDIT_TOOL_NAME = 'openpencil_edit' as const
+
+/**
+ * Historical render name retained only by the browser presentation layer so
+ * existing conversation cards and details panels remain replayable. The host
+ * deliberately does not register this alias as a model-facing tool.
+ */
+export const LEGACY_DESIGN_RENDER_TOOL_NAME = 'design_render' as const
+
+export const OPENPENCIL_TOOL_NAMES = [
+  OPENPENCIL_RENDER_TOOL_NAME,
+  OPENPENCIL_SELECTION_TOOL_NAME,
+  OPENPENCIL_CREATE_TOOL_NAME,
+  OPENPENCIL_EDIT_TOOL_NAME,
+] as const

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,5 +1,5 @@
 /**
- * `design_render` — render a `.op` design document to PNG without a
+ * `openpencil_render` — render a `.op` design document to PNG without a
  * window. OpenPencil's own exporter is the exact primary path; Jian is an
  * explicitly-labelled runtime-preview fallback when that binary is absent.
  *
@@ -30,6 +30,7 @@ import {
 } from './renderer.js'
 import type { ViewerAssetController } from './viewer-assets.js'
 import type { EditorHostController } from './editor-host.js'
+import { OPENPENCIL_RENDER_TOOL_NAME } from './tool-names.js'
 
 /** Session workspace the caller resolves paths against (mirrors first-party tools). */
 function sessionWorkspace(exec: ToolRunContext): string {
@@ -65,14 +66,14 @@ export interface DesignRenderArgs {
   editable?: boolean
 }
 
-/** Create the `design_render` tool definition bound to one controller. */
+/** Create the `openpencil_render` tool definition bound to one controller. */
 export function createDesignRenderTool(
   controller: RenderAccessController,
   viewerAssets?: ViewerAssetController,
   editorHost?: EditorHostController,
 ) {
   return defineTool({
-    name: 'design_render',
+    name: OPENPENCIL_RENDER_TOOL_NAME,
     description: 'Render an OpenPencil .op design document exactly as the design canvas, '
       + 'then show a PNG and an optional interactive read-only canvas in the conversation. '
       + 'Give the absolute path to a .op file (or a path relative to the session workspace). '
@@ -97,7 +98,7 @@ export function createDesignRenderTool(
           mimeType: { type: 'string', const: 'image/png', required: true },
           kind: { type: 'string', const: 'image', required: true },
           description: { type: 'string', required: true },
-          sourceTool: { type: 'string', const: 'design_render', required: true },
+          sourceTool: { type: 'string', const: OPENPENCIL_RENDER_TOOL_NAME, required: true },
           previewIntent: { type: 'string', const: 'image', required: true },
           bytes: { type: 'integer', required: true },
           width: { type: 'integer' },
@@ -158,7 +159,7 @@ export function createDesignRenderTool(
       const openPencil = findOpenPencilBinary()
       if (openPencil !== undefined) {
         if (args.width !== undefined || args.height !== undefined) {
-          throw new Error('design_render: width/height are not supported by the exact OpenPencil renderer; omit them and use scale')
+          throw new Error(`${OPENPENCIL_RENDER_TOOL_NAME}: width/height are not supported by the exact OpenPencil renderer; omit them and use scale`)
         }
         try {
           const exact = await runOpenPencilRender({
@@ -224,7 +225,7 @@ export function createDesignRenderTool(
         mimeType: 'image/png',
         kind: 'image',
         description: `Rendered ${input} with ${renderer} (${fidelity})`,
-        sourceTool: 'design_render',
+        sourceTool: OPENPENCIL_RENDER_TOOL_NAME,
         previewIntent: 'image',
         bytes: verified.bytes,
         width: verified.width,

--- a/tests/client.test.mjs
+++ b/tests/client.test.mjs
@@ -33,6 +33,27 @@ function memoryStorage() {
   }
 }
 
+function flushAsync() {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+function controlledPollTimer() {
+  const scheduled = []
+  const cancelled = []
+  return {
+    scheduled,
+    cancelled,
+    timer: {
+      schedule(callback, delayMs) {
+        const handle = { callback, delayMs }
+        scheduled.push(handle)
+        return handle
+      },
+      cancel(handle) { cancelled.push(handle) },
+    },
+  }
+}
+
 test('keeps the established v1 PNG envelope replayable', () => {
   const grant = client.grantOf(settled({
     $dshOpenPencil: {
@@ -197,6 +218,12 @@ test('gallery toolbar controls share a vertically-centered box', () => {
     lineHeight: 1,
     verticalAlign: 'middle',
   })
+  assert.deepEqual(client.GALLERY_TOOLBAR_CONTROL_CONTENT_LAYOUT, {
+    display: 'inline-block',
+    lineHeight: 1,
+    transform: 'translateY(-1px)',
+    pointerEvents: 'none',
+  })
 })
 
 test('gallery and render-card copy follow the resolved DSH locale', () => {
@@ -215,16 +242,59 @@ test('gallery and render-card copy follow the resolved DSH locale', () => {
   assert.equal(client.frameLabel({}, 3, 'en'), 'Frame 4')
 
   const zhCard = client.designRenderCopy('zh')
-  assert.equal(zhCard.designRender, '设计渲染')
+  assert.equal(zhCard.designRender, 'OpenPencil 渲染')
   assert.equal(zhCard.openInteractiveCanvas, '打开交互画布')
   assert.equal(zhCard.editInSidebar, '在侧边栏编辑')
   assert.equal(zhCard.downloadPng, '下载 PNG')
   assert.equal(zhCard.noPreview, '当前宿主没有可用的预览通道。')
 
   const enCard = client.designRenderCopy('en')
-  assert.equal(enCard.designRender, 'Design render')
+  assert.equal(enCard.designRender, 'OpenPencil render')
   assert.equal(enCard.openInteractiveCanvas, 'Open interactive canvas')
   assert.equal(enCard.noPreview, 'No preview channel available in this host.')
+})
+
+test('live OpenPencil selection is parsed, scoped by DSH session, and labelled bilingually', () => {
+  const emptyBeforePoll = client.getOpenPencilSelectionSnapshot('session-empty')
+  assert.strictEqual(
+    client.getOpenPencilSelectionSnapshot('session-empty'),
+    emptyBeforePoll,
+    'empty snapshots must stay referentially stable for useSyncExternalStore',
+  )
+  const selection = client.liveSelectionOf({
+    sourcePath: '/designs/home.op', activePageId: 'page-1', selectedIds: ['n42'], updatedAt: 7,
+    nodes: [{ id: 'n42', type: 'text', name: 'Hero title', x: 12, y: 20, width: 320, height: 48 }],
+  })
+  assert.ok(selection)
+  assert.equal(client.hasOpenPencilSelection(selection), true)
+  assert.equal(client.hasOpenPencilSelection({ ...selection, selectedIds: [] }), false)
+  assert.deepEqual(client.OPENPENCIL_SELECTION_DOCK_LAYOUT, {
+    boxSizing: 'border-box',
+    flex: 'none',
+    width: 'calc(100% - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-side-clearance, 16px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))',
+    maxWidth: 'calc(var(--dsh-composer-card-max-width, 780px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px) - var(--dsh-composer-dock-inset, 8px))',
+    margin: '0 auto',
+  })
+  assert.equal(client.selectionNodeLabel(selection, 'en'), 'Hero title')
+  assert.equal(client.selectionNodeLabel(selection, 'zh'), 'Hero title')
+  assert.equal(client.selectionNodeDetail(selection, 'en'), 'text · 320 × 48 · n42')
+
+  client.publishOpenPencilSelection('session-a', selection)
+  assert.equal(client.getOpenPencilSelectionSnapshot('session-a').selection.nodes[0].id, 'n42')
+  assert.equal(client.getOpenPencilSelectionSnapshot('session-b').selection, undefined)
+  client.clearOpenPencilSelection('session-b')
+  assert.ok(client.getOpenPencilSelectionSnapshot('session-a').selection)
+  client.clearOpenPencilSelection('session-a', '/designs/home.op')
+  assert.equal(client.getOpenPencilSelectionSnapshot('session-a').selection, undefined)
+})
+
+test('selection labels retain id-only and multi-select fallbacks', () => {
+  const multi = {
+    sourcePath: '/designs/home.op', activePageId: 'page-1', selectedIds: ['n1', 'n2'], nodes: [], updatedAt: 1,
+  }
+  assert.equal(client.selectionNodeLabel(multi, 'zh'), '已选择 2 个节点')
+  assert.equal(client.selectionNodeLabel(multi, 'en'), '2 nodes selected')
+  assert.equal(client.selectionNodeDetail(multi, 'en'), 'n1 · n2')
 })
 
 test('gallery zoom shortcuts require Ctrl or Command', () => {
@@ -372,6 +442,32 @@ test('editor bridge emits the strict resolved DSH theme message', () => {
   assert.deepEqual(client.inject, ['slots', 'theme', 'locale'])
 })
 
+test('registers canonical OpenPencil render views and client-only legacy replay aliases', () => {
+  const registrations = []
+  client.apply({
+    on() { return () => {} },
+    theme: { getTheme: () => ({ active: { colorScheme: 'light' } }) },
+    locale: { getLocale: () => ({ active: 'en' }) },
+    slots: {
+      inject(_name, install) { return install() },
+      register(definition, component) {
+        registrations.push({ definition, component })
+        return () => {}
+      },
+    },
+  })
+
+  assert.equal(client.OPENPENCIL_RENDER_TOOL_NAME, 'openpencil_render')
+  assert.equal(client.LEGACY_DESIGN_RENDER_TOOL_NAME, 'design_render')
+  assert.deepEqual(registrations.map(({ definition }) => definition), [
+    { name: 'tool.call.toolview', key: 'openpencil_render' },
+    { name: 'tool.details.toolview', key: 'openpencil_render' },
+    { name: 'tool.call.toolview', key: 'design_render' },
+    { name: 'tool.details.toolview', key: 'design_render' },
+    { name: 'conversation.input.dock', id: 'openpencil-selection', order: 30 },
+  ])
+})
+
 test('editor bridge maps and emits the resolved DSH locale as BCP 47', () => {
   assert.equal(client.editorLocaleFromDsh('zh'), 'zh-CN')
   assert.equal(client.editorLocaleFromDsh('en'), 'en-US')
@@ -399,6 +495,87 @@ test('editor panel chrome follows the resolved editor locale', () => {
   assert.equal(en.loading, 'Loading editable OpenPencil canvas…')
   assert.equal(en.editorTitle('home.op'), 'OpenPencil editor: home.op')
   assert.equal(en.syncConflict(7), 'The source changed outside this editor (server v7). Save was stopped.')
+})
+
+test('selection polling stops and clears state on terminal 404 and 410 responses', async () => {
+  for (const status of [404, 410]) {
+    const clock = controlledPollTimer()
+    let stops = 0
+    let calls = 0
+    client.startEditorSelectionPolling({
+      url: `/editor/selection/${status}`,
+      fetcher: async () => {
+        calls += 1
+        return new Response(null, { status })
+      },
+      onValue() { assert.fail('terminal responses must not publish a selection') },
+      onStop() { stops += 1 },
+      timer: clock.timer,
+    })
+    await flushAsync()
+    assert.equal(calls, 1)
+    assert.equal(stops, 1, `${status} must clear the live selection`)
+    assert.equal(clock.scheduled.length, 0, `${status} must not schedule another poll`)
+  }
+})
+
+test('selection polling retries transient failures and cleanup cancels the next timer', async () => {
+  const clock = controlledPollTimer()
+  const values = []
+  let calls = 0
+  let stops = 0
+  const stop = client.startEditorSelectionPolling({
+    url: '/editor/selection/transient',
+    fetcher: async () => {
+      calls += 1
+      if (calls === 1) return new Response(null, { status: 503 })
+      return Response.json({ selection: { selectedIds: ['n1'] } })
+    },
+    onValue(value) { values.push(value) },
+    onStop() { stops += 1 },
+    intervalMs: 123,
+    timer: clock.timer,
+  })
+  await flushAsync()
+  assert.equal(clock.scheduled.length, 1)
+  assert.equal(clock.scheduled[0].delayMs, 123)
+
+  clock.scheduled.shift().callback()
+  await flushAsync()
+  assert.equal(calls, 2)
+  assert.deepEqual(values, [{ selection: { selectedIds: ['n1'] } }])
+  assert.equal(clock.scheduled.length, 1)
+
+  const pending = clock.scheduled[0]
+  stop()
+  stop()
+  assert.deepEqual(clock.cancelled, [pending])
+  assert.equal(stops, 1, 'cleanup must clear selection exactly once')
+})
+
+test('selection polling cleanup aborts an in-flight request without scheduling a retry', async () => {
+  const clock = controlledPollTimer()
+  let observedSignal
+  let stops = 0
+  const stop = client.startEditorSelectionPolling({
+    url: '/editor/selection/in-flight',
+    fetcher: async (_url, init = {}) => {
+      observedSignal = init.signal
+      return new Promise((_resolve, reject) => {
+        observedSignal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+      })
+    },
+    onValue() { assert.fail('an aborted request must not publish a selection') },
+    onStop() { stops += 1 },
+    timer: clock.timer,
+  })
+  await flushAsync()
+  assert.equal(observedSignal.aborted, false)
+  stop()
+  await flushAsync()
+  assert.equal(observedSignal.aborted, true)
+  assert.equal(stops, 1)
+  assert.equal(clock.scheduled.length, 0)
 })
 
 test('editor control capabilities remain on the DSH origin', () => {
@@ -499,7 +676,7 @@ test('current or renewed editor contracts never reopen an immutable historical s
       return Response.json(launchWithoutDoc)
     },
   }), /omitted current docJson/)
-  assert.equal(currentCalls, 1, 'current contract must not fetch the historical snapshot')
+  assert.equal(currentCalls, 2, 'current contract must close its launched daemon without fetching the historical snapshot')
 
   let renewedCalls = 0
   await assert.rejects(client.prepareManagedEditor({
@@ -516,7 +693,44 @@ test('current or renewed editor contracts never reopen an immutable historical s
       return Response.json(launchWithoutDoc)
     },
   }), /omitted current docJson/)
-  assert.equal(renewedCalls, 3, 'renewed launch must not make a fourth historical-document request')
+  assert.equal(renewedCalls, 4, 'renewed launch must close its daemon instead of reading the historical document')
+})
+
+test('cancelled editor mount closes exactly the launch that completed after cancellation', async () => {
+  const calls = []
+  const fetcher = async (url, init = {}) => {
+    calls.push({ url, init })
+    if (calls.length === 1) {
+      return Response.json({
+        sessionId: 'cancelled-session',
+        iframeUrl: 'http://127.0.0.1:49155/?embed=vscode',
+        token: 'daemon-secret',
+        saveUrl: '/editor/session/cancelled-session/save',
+        closeUrl: '/editor/session/cancelled-session',
+        docJson: '{"source":"current"}',
+      })
+    }
+    return Response.json({ ok: true })
+  }
+
+  const prepared = await client.prepareManagedEditorForMount({
+    enabled: true,
+    launchUrl: '/editor/cancelled-launch',
+    refreshUrl: '/editor/cancelled-refresh',
+  }, {
+    path: '/workspace/design.op',
+    url: '/render/document',
+  }, () => false, { fetcher, sessionId: 'dsh-session' })
+
+  assert.equal(prepared, undefined)
+  assert.equal(calls.length, 2)
+  assert.equal(calls[1].url, 'http://127.0.0.1:3080/editor/session/cancelled-session')
+  assert.equal(calls[1].init.method, 'DELETE')
+  assert.equal(calls[1].init.keepalive, true)
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    sessionId: 'cancelled-session',
+    dirty: false,
+  })
 })
 
 test('editor launch refresh is limited to 410 and one retry', async () => {

--- a/tests/client.test.mjs
+++ b/tests/client.test.mjs
@@ -244,6 +244,7 @@ test('gallery and render-card copy follow the resolved DSH locale', () => {
   const zhCard = client.designRenderCopy('zh')
   assert.equal(zhCard.designRender, 'OpenPencil 渲染')
   assert.equal(zhCard.openInteractiveCanvas, '打开交互画布')
+  assert.equal(zhCard.editCanvas, '编辑画布')
   assert.equal(zhCard.editInSidebar, '在侧边栏编辑')
   assert.equal(zhCard.downloadPng, '下载 PNG')
   assert.equal(zhCard.noPreview, '当前宿主没有可用的预览通道。')
@@ -251,6 +252,7 @@ test('gallery and render-card copy follow the resolved DSH locale', () => {
   const enCard = client.designRenderCopy('en')
   assert.equal(enCard.designRender, 'OpenPencil render')
   assert.equal(enCard.openInteractiveCanvas, 'Open interactive canvas')
+  assert.equal(enCard.editCanvas, 'Edit canvas')
   assert.equal(enCard.noPreview, 'No preview channel available in this host.')
 })
 
@@ -468,6 +470,51 @@ test('registers canonical OpenPencil render views and client-only legacy replay 
   ])
 })
 
+test('stock rc.2 can leave the optional details slot undeclared', () => {
+  const registrations = []
+  const pending = []
+  client.apply({
+    on() { return () => {} },
+    theme: { getTheme: () => ({ active: { colorScheme: 'light' } }) },
+    locale: { getLocale: () => ({ active: 'en' }) },
+    slots: {
+      inject(name, install) {
+        if (name === 'tool.details.toolview') {
+          pending.push(name)
+          return () => {}
+        }
+        return install()
+      },
+      register(definition) {
+        registrations.push(definition)
+        return () => {}
+      },
+    },
+  })
+
+  assert.deepEqual(pending, ['tool.details.toolview', 'tool.details.toolview'])
+  assert.deepEqual(registrations, [
+    { name: 'tool.call.toolview', key: 'openpencil_render' },
+    { name: 'tool.call.toolview', key: 'design_render' },
+    { name: 'conversation.input.dock', id: 'openpencil-selection', order: 30 },
+  ])
+})
+
+test('editor launch prefers native details and falls back to the plugin modal', () => {
+  const calls = []
+  assert.equal(client.requestOpenPencilEditor(
+    () => { calls.push('details') },
+    () => { calls.push('modal') },
+  ), 'details')
+  assert.deepEqual(calls, ['details'])
+
+  assert.equal(client.requestOpenPencilEditor(
+    undefined,
+    () => { calls.push('modal') },
+  ), 'modal')
+  assert.deepEqual(calls, ['details', 'modal'])
+})
+
 test('editor bridge maps and emits the resolved DSH locale as BCP 47', () => {
   assert.equal(client.editorLocaleFromDsh('zh'), 'zh-CN')
   assert.equal(client.editorLocaleFromDsh('en'), 'en-US')
@@ -495,6 +542,44 @@ test('editor panel chrome follows the resolved editor locale', () => {
   assert.equal(en.loading, 'Loading editable OpenPencil canvas…')
   assert.equal(en.editorTitle('home.op'), 'OpenPencil editor: home.op')
   assert.equal(en.syncConflict(7), 'The source changed outside this editor (server v7). Save was stopped.')
+})
+
+test('fallback editor modal chrome follows the resolved editor locale', () => {
+  assert.deepEqual(client.editorModalCopy('zh-CN'), {
+    title: 'OpenPencil 编辑器',
+    close: '关闭',
+    discard: 'OpenPencil 中有未保存的更改，确定关闭并放弃吗？',
+  })
+  assert.deepEqual(client.editorModalCopy('en-US'), {
+    title: 'OpenPencil editor',
+    close: 'Close',
+    discard: 'OpenPencil has unsaved changes. Close and discard them?',
+  })
+})
+
+test('fallback editor modal confirms only when the managed editor is dirty', () => {
+  const cleanRoot = { querySelector() { return null } }
+  let confirmations = 0
+  assert.equal(client.confirmEditorModalClose(cleanRoot, 'discard?', () => {
+    confirmations += 1
+    return false
+  }), true)
+  assert.equal(confirmations, 0)
+
+  const dirtyRoot = { querySelector(selector) {
+    assert.equal(selector, '[data-tool-details-dirty="true"]')
+    return {}
+  } }
+  assert.equal(client.confirmEditorModalClose(dirtyRoot, 'discard?', message => {
+    confirmations += 1
+    assert.equal(message, 'discard?')
+    return false
+  }), false)
+  assert.equal(client.confirmEditorModalClose(dirtyRoot, 'discard?', () => {
+    confirmations += 1
+    return true
+  }), true)
+  assert.equal(confirmations, 2)
 })
 
 test('selection polling stops and clears state on terminal 404 and 410 responses', async () => {

--- a/tests/editor-host-lifecycle.test.mjs
+++ b/tests/editor-host-lifecycle.test.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict'
+import { createHash, randomBytes } from 'node:crypto'
+import { createServer, request as httpRequest } from 'node:http'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+const fakeHostSource = `#!/usr/bin/env node
+const fs = require('node:fs')
+const http = require('node:http')
+const delay = Number(process.env.FAKE_EDITOR_HANDSHAKE_DELAY_MS || 0)
+const logPath = process.env.FAKE_EDITOR_LOG
+const server = http.createServer((_req, res) => {
+  res.statusCode = 200
+  res.setHeader('content-type', 'application/javascript')
+  res.end('/* fake OpenPencil web host */')
+})
+let closing = false
+function close() {
+  if (closing) return
+  closing = true
+  server.close(() => process.exit(0))
+  setTimeout(() => process.exit(0), 200).unref()
+}
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port
+  fs.appendFileSync(logPath, JSON.stringify({ pid: process.pid, port }) + '\\n')
+  setTimeout(() => {
+    process.stdout.write(JSON.stringify({ ok: true, port, token: 'fake-daemon-token-123456789', version: 'test' }) + '\\n')
+  }, delay)
+})
+process.stdin.resume()
+process.stdin.on('end', close)
+process.on('SIGTERM', close)
+`
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function closeServer(server) {
+  return new Promise(resolve => server.close(resolve))
+}
+
+async function waitForHosts(path, count) {
+  const deadline = Date.now() + 3_000
+  while (Date.now() < deadline) {
+    const text = await readFile(path, 'utf8').catch(() => '')
+    const entries = text.trim() === '' ? [] : text.trim().split('\n').map(line => JSON.parse(line))
+    if (entries.length >= count) return entries
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`fake editor host did not record ${count} start(s)`)
+}
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitForExit(pid) {
+  const deadline = Date.now() + 3_000
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`fake editor host ${pid} did not exit`)
+}
+
+async function createHarness(delayMs) {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-openpencil-editor-lifecycle-'))
+  const binary = join(root, 'fake-editor-host.cjs')
+  const logPath = join(root, 'hosts.jsonl')
+  const sourcePath = join(root, 'design.op')
+  const document = '{"version":1,"children":[]}'
+  await Promise.all([
+    writeFile(binary, fakeHostSource),
+    writeFile(logPath, ''),
+    writeFile(sourcePath, document),
+  ])
+  await chmod(binary, 0o755)
+
+  const previousBinary = process.env.DSH_OPENPENCIL_EDITOR_BINARY
+  const previousDelay = process.env.FAKE_EDITOR_HANDSHAKE_DELAY_MS
+  const previousLog = process.env.FAKE_EDITOR_LOG
+  process.env.DSH_OPENPENCIL_EDITOR_BINARY = binary
+  process.env.FAKE_EDITOR_HANDSHAKE_DELAY_MS = String(delayMs)
+  process.env.FAKE_EDITOR_LOG = logPath
+
+  const { EditorHostController } = await import(`../lib/editor-host.js?lifecycle=${Date.now()}-${Math.random()}`)
+  const controller = new EditorHostController(randomBytes(32))
+  const detach = controller.attachRoute()
+  const grant = controller.grantFor(sourcePath, sha256(document))
+  assert.ok(grant)
+
+  const server = createServer((req, res) => { void controller.handle(req, res) })
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  assert.equal(typeof address, 'object')
+  const origin = `http://127.0.0.1:${address.port}`
+  const request = (path, init = {}) => fetch(`${origin}${path}`, {
+    ...init,
+    headers: { origin, ...(init.headers ?? {}) },
+  })
+
+  return {
+    controller,
+    detach,
+    grant,
+    logPath,
+    request,
+    origin,
+    async cleanup() {
+      detach()
+      await controller.dispose()
+      await closeServer(server)
+      if (previousBinary === undefined) delete process.env.DSH_OPENPENCIL_EDITOR_BINARY
+      else process.env.DSH_OPENPENCIL_EDITOR_BINARY = previousBinary
+      if (previousDelay === undefined) delete process.env.FAKE_EDITOR_HANDSHAKE_DELAY_MS
+      else process.env.FAKE_EDITOR_HANDSHAKE_DELAY_MS = previousDelay
+      if (previousLog === undefined) delete process.env.FAKE_EDITOR_LOG
+      else process.env.FAKE_EDITOR_LOG = previousLog
+      await rm(root, { recursive: true, force: true })
+    },
+  }
+}
+
+test('concurrent launch requests serialize and stale cleanup cannot close the successor', async () => {
+  const harness = await createHarness(120)
+  try {
+    const firstPending = harness.request(harness.grant.launchUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'owner-one' }),
+    })
+    await waitForHosts(harness.logPath, 1)
+    const secondPending = harness.request(harness.grant.launchUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'owner-two' }),
+    })
+
+    const first = await (await firstPending).json()
+    const second = await (await secondPending).json()
+    const hosts = await waitForHosts(harness.logPath, 2)
+
+    assert.notEqual(first.sessionId, second.sessionId)
+    assert.equal(isAlive(hosts[0].pid), false, 'successor launch must retire the first child')
+    assert.equal((await fetch(second.iframeUrl)).status, 200)
+
+    const staleClose = await harness.request(first.closeUrl, {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: first.sessionId }),
+    })
+    assert.equal(staleClose.status, 200)
+    assert.equal((await fetch(second.iframeUrl)).status, 200, 'stale effect cleanup must not stop the successor')
+
+    const currentClose = await harness.request(second.closeUrl, {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: second.sessionId }),
+    })
+    assert.equal(currentClose.status, 200)
+    assert.equal(isAlive(hosts[1].pid), false)
+  } finally {
+    await harness.cleanup()
+  }
+})
+
+test('route disposal terminates a pending launch and prevents late registration', async () => {
+  const harness = await createHarness(5_000)
+  try {
+    const pending = harness.request(harness.grant.launchUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'owner-pending' }),
+    })
+    const [host] = await waitForHosts(harness.logPath, 1)
+    harness.detach()
+    await harness.controller.dispose()
+
+    const response = await pending
+    assert.notEqual(response.status, 200)
+    assert.equal(isAlive(host.pid), false, 'pending managed child must be reaped during disposal')
+    await assert.rejects(
+      harness.controller.getActiveSelection(),
+      /No active OpenPencil editor/,
+    )
+  } finally {
+    await harness.cleanup()
+  }
+})
+
+test('client disconnect before launch response terminates the precise pending child', async () => {
+  const harness = await createHarness(5_000)
+  try {
+    const requestClosed = new Promise(resolve => {
+      const request = httpRequest(`${harness.origin}${harness.grant.launchUrl}`, {
+        method: 'POST',
+        headers: {
+          origin: harness.origin,
+          'content-type': 'application/json',
+        },
+      })
+      request.once('error', resolve)
+      request.end(JSON.stringify({ sessionId: 'owner-disconnected' }))
+      void waitForHosts(harness.logPath, 1).then(() => request.destroy())
+    })
+    const [host] = await waitForHosts(harness.logPath, 1)
+    await requestClosed
+    await waitForExit(host.pid)
+    await assert.rejects(
+      harness.controller.getActiveSelection(),
+      /No active OpenPencil editor/,
+    )
+  } finally {
+    await harness.cleanup()
+  }
+})

--- a/tests/host-service.test.mjs
+++ b/tests/host-service.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+test('plugin mounts its HTTP routes through the rc.2 webServer service', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-openpencil-host-api-'))
+  const previousDshHome = process.env.DSH_HOME
+  process.env.DSH_HOME = join(root, 'dsh-home')
+
+  const routeRegistrations = []
+  const routeRemovals = []
+  const injectedServices = []
+  const registeredTools = []
+  let disposeInjectedRoutes
+
+  const webServer = {
+    register(route) {
+      routeRegistrations.push(route)
+      return () => { routeRemovals.push(route.path) }
+    },
+  }
+  const ctx = {
+    tools: {
+      register(tool) {
+        registeredTools.push(tool)
+        return () => {}
+      },
+    },
+    effect(install) {
+      return install()
+    },
+    inject(services, install) {
+      injectedServices.push([...services])
+      install({
+        webServer,
+        effect(mount) {
+          disposeInjectedRoutes = mount()
+          return disposeInjectedRoutes
+        },
+      })
+    },
+    logger: { info() {} },
+  }
+
+  try {
+    const { apply } = await import(`../lib/index.js?host-api=${Date.now()}`)
+    const disposePlugin = await apply(ctx)
+
+    assert.deepEqual(injectedServices, [['webServer']])
+    assert.equal(registeredTools.length, 4)
+    assert.deepEqual(registeredTools.map(tool => tool.name), [
+      'openpencil_render',
+      'openpencil_selection',
+      'openpencil_create',
+      'openpencil_edit',
+    ])
+    assert.equal(registeredTools.some(tool => tool.name === 'design_render'), false, 'legacy render alias must remain client-only')
+    assert.equal(registeredTools[0].output.schema.properties.sourceTool.const, 'openpencil_render')
+    assert.deepEqual(
+      routeRegistrations.map(route => ({ kind: route.kind, path: route.path })),
+      [
+        { kind: 'prefix', path: '/_dsh/dsh-openpencil/render' },
+        { kind: 'prefix', path: '/_dsh/dsh-openpencil/viewer-assets' },
+        { kind: 'prefix', path: '/_dsh/dsh-openpencil/editor' },
+      ],
+    )
+    assert.equal(typeof disposeInjectedRoutes, 'function')
+
+    disposeInjectedRoutes()
+    assert.deepEqual(routeRemovals.sort(), routeRegistrations.map(route => route.path).sort())
+    disposePlugin()
+  } finally {
+    if (previousDshHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousDshHome
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/mcp-client.test.mjs
+++ b/tests/mcp-client.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+const mcp = await import('../lib/mcp-client.js')
+
+test('parses successful OpenPencil MCP text JSON', () => {
+  const result = mcp.parseOpenPencilMcpResponse('get_selection', {
+    jsonrpc: '2.0', id: 1,
+    result: {
+      content: [{ type: 'text', text: '{"selectedIds":["n1"],"activePageId":"p1","nodes":[]}' }],
+    },
+  })
+  assert.deepEqual(result.value, { selectedIds: ['n1'], activePageId: 'p1', nodes: [] })
+})
+
+test('surfaces JSON-RPC, MCP isError, and transactional applied=false failures', () => {
+  assert.throws(() => mcp.parseOpenPencilMcpResponse('x', {
+    jsonrpc: '2.0', id: 1, error: { message: 'denied' },
+  }), /denied/)
+  assert.throws(() => mcp.parseOpenPencilMcpResponse('x', {
+    jsonrpc: '2.0', id: 1, result: { isError: true, content: [{ type: 'text', text: 'bad patch' }] },
+  }), /bad patch/)
+  assert.throws(() => mcp.parseOpenPencilMcpResponse('batch_design', {
+    jsonrpc: '2.0', id: 1,
+    result: { content: [{ type: 'text', text: '{"applied":false,"errors":["line 2 failed"]}' }] },
+  }), /line 2 failed/)
+})
+
+test('projects a bounded selection snapshot with id-only fallbacks', () => {
+  const selection = mcp.selectionSnapshotFromMcp('/tmp/demo.op', {
+    activePageId: 'p1', selectedIds: ['n1', '', 7],
+    nodes: [{ id: 'n1', type: 'frame', name: 'Home', x: 1, y: 2, width: 375, height: 812 }, { nope: true }],
+  }, 123)
+  assert.deepEqual(selection, {
+    sourcePath: '/tmp/demo.op', activePageId: 'p1', selectedIds: ['n1'], updatedAt: 123,
+    nodes: [{ id: 'n1', type: 'frame', name: 'Home', x: 1, y: 2, width: 375, height: 812 }],
+  })
+})

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -4,11 +4,11 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "rootDir": "src/client",
+    "rootDir": "src",
     "outDir": ".client-build",
     "declaration": true,
     "emitDeclarationOnly": true,
-    "declarationDir": "lib/types/client",
+    "declarationDir": "lib/types",
     "sourceMap": true,
     "strict": true,
     "skipLibCheck": true,
@@ -18,6 +18,6 @@
     "noEmitOnError": true,
     "types": ["react"]
   },
-  "include": ["src/client/**/*.ts", "src/client/**/*.tsx"],
+  "include": ["src/client/**/*.ts", "src/client/**/*.tsx", "src/tool-names.ts"],
   "exclude": ["lib", ".client-build", "node_modules"]
 }


### PR DESCRIPTION
## What changed

- add OpenPencil-native `openpencil_selection`, `openpencil_create`, and `openpencil_edit` tools alongside exact multi-frame rendering
- show the live OpenPencil canvas selection above the DSH composer and target edits to the selected node
- harden managed-editor launch, cleanup, save-conflict, and selection-polling lifecycles
- migrate the plugin to the DSH rc.2 `webServer` service and branded `openpencil_*` tool names
- preserve historical `design_render` cards through client-only replay aliases
- add progressive editor presentation: native Tool details when DSH exposes the seam, full-screen managed-editor fallback on stock rc.2
- update generated production assets, documentation, and regression coverage

## Why

The plugin now supports the full DSH-to-OpenPencil workflow: render designs, open the editable canvas, expose the user's current canvas selection, and let the DSH Agent generate or modify nodes directly without handing control to a second model.

## User impact

- new calls use explicit `openpencil_render`, `openpencil_selection`, `openpencil_create`, and `openpencil_edit` names
- existing `design_render` conversation cards remain replayable
- canvas edits are applied live and remain unsaved until the editor Save action
- stock DSH rc.2 opens the full editor in a plugin-owned modal; hosts with the keyed Tool-details seam use the native right-hand panel
- editor teardown and rapid remounts no longer leak or close the wrong managed process

## Validation

- `npm run build`
- `npm run test:client` (43 passed)
- `npm run test:host-api` (4 passed)
- `npm run test:mcp` (3 passed)
- `npm run test:viewer-assets`
- real four-frame `.op` exact-render/editor/MCP/save smoke
- stock rc.2 client build with the optional details slot undeclared
- `npm pack --dry-run --ignore-scripts`
- credential and local-path scan

## Compatibility

The plugin does not require a DSH core patch. On stock rc.2 the optional `tool.details.toolview` registration remains dormant and the edit action opens the plugin-owned full-screen editor. If a later DSH build declares the keyed details seam and supplies `openDetails`, the same plugin automatically uses the native details column.
